### PR TITLE
Story approval workflow

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,13 +21,15 @@ gem 'pundit', '~> 1.0.1'
 
 gem 'neat'
 gem 'bourbon'
+gem 'redcarpet'
+gem 'foundation-icons-sass-rails'
 
 gem 'airbrake'
 gem 'omniauth-github', '~> 1.1.2'
 gem 'octokit'
-gem 'foundation-icons-sass-rails'
 
 gem 'email_validator'
+gem 'aasm'
 
 group :development do
   gem 'guard-livereload', '~> 2.4', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,6 +16,7 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
+    aasm (4.2.0)
     actionmailer (4.2.3)
       actionpack (= 4.2.3)
       actionview (= 4.2.3)
@@ -261,22 +262,23 @@ GEM
     rb-fsevent (0.9.5)
     rb-inotify (0.9.5)
       ffi (>= 0.5.0)
+    redcarpet (3.3.2)
     representable (2.2.3)
       multi_json
       nokogiri
       uber (~> 0.0.7)
-    rspec-core (3.3.1)
+    rspec-core (3.3.2)
       rspec-support (~> 3.3.0)
-    rspec-expectations (3.3.0)
+    rspec-expectations (3.3.1)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.3.0)
     rspec-its (1.2.0)
       rspec-core (>= 3.0.0)
       rspec-expectations (>= 3.0.0)
-    rspec-mocks (3.3.1)
+    rspec-mocks (3.3.2)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.3.0)
-    rspec-rails (3.3.2)
+    rspec-rails (3.3.3)
       actionpack (>= 3.0, < 4.3)
       activesupport (>= 3.0, < 4.3)
       railties (>= 3.0, < 4.3)
@@ -342,6 +344,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  aasm
   activerecord-session_store
   airbrake
   attr_encrypted
@@ -369,6 +372,7 @@ DEPENDENCIES
   quiet_assets
   rails (= 4.2.3)
   rails_12factor
+  redcarpet
   rspec-its
   rspec-rails
   sass-rails (~> 5.0)

--- a/app/assets/stylesheets/_story.scss
+++ b/app/assets/stylesheets/_story.scss
@@ -1,8 +1,11 @@
 .story {
-  @include display(flex);
-  @include align-items(baseline);
-  @include justify-content(space-between);
-  /* padding: 0.2em; */
+  .row {
+    @include display(flex);
+    @include align-items(baseline);
+    @include justify-content(space-between);
+    @include flex-direction(row);
+    /* padding: 0.2em; */
+  }
 
   .type {
     padding-right: 0.6em;

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -19,8 +19,8 @@ class ApplicationController < ActionController::Base
   end
 
   def project
-    @project ||= if user_signed_in? && current_user.has_api_key?
-                   TrackerProject.new(api_token: current_user.api_key)
+    @project ||= if user_signed_in?
+                   current_user.connection
                  else
                    TrackerProject.new
                  end

--- a/app/controllers/iteration_stories_controller.rb
+++ b/app/controllers/iteration_stories_controller.rb
@@ -13,14 +13,13 @@ class IterationStoriesController < ApplicationController
     formatted_story = StoryFormatter.new(story_params)
     formatted_story.after_id = last_story.to_param
     authorize formatted_story, :create?
-    @story = project.create_story(formatted_story.as_params)
-    if @story.id.blank?
+    @story = Story.create_from_formatter(current_user, formatted_story.as_params)
+    if @story.persisted?
+      flash[:success] = "Story has been submitted for review."
+      redirect_to iterations_path
+    else
       flash[:error] = "Could not save the story."
       render action: 'new'
-    else
-      current_user.stories.create!(external_ref: @story.id)
-      flash[:success] = "Story has been created."
-      redirect_to iterations_path
     end
   end
 

--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -2,6 +2,12 @@ class StoriesController < ApplicationController
   before_filter :authenticate_user!
   after_action :verify_authorized
 
+  def index
+    @stories = Story.submitted.all
+    authorize @stories
+    render
+  end
+
   def new
     @story = StoryFormatter.new
     authorize @story, :create?
@@ -11,14 +17,13 @@ class StoriesController < ApplicationController
   def create
     formatted_story = StoryFormatter.new(story_params)
     authorize formatted_story, :create?
-    @story = project.create_story(formatted_story.as_params)
-    if @story.id.blank?
+    @story = Story.create_from_formatter(current_user, formatted_story.as_params)
+    if @story.persisted?
+      flash[:success] = "Story has been submitted for review."
+      redirect_to iterations_path
+    else
       flash[:error] = "Could not save the story."
       render action: 'new'
-    else
-      current_user.stories.create!(external_ref: @story.id)
-      flash[:success] = "Story has been created with ID <a href='#{@story.url}'>##{@story.id}</a>."
-      redirect_to iterations_path
     end
   end
 

--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -27,7 +27,33 @@ class StoriesController < ApplicationController
     end
   end
 
+  def update
+    @story = Story.find(params[:id])
+    authorize @story
+    if handle_state_change(@story, story_update_params[:state])
+      flash[:success] = "Story has been #{@story.state}."
+    else
+      flash[:notice] = "Cannot update story."
+    end
+    redirect_to stories_path
+  end
+
 private
+
+  def handle_state_change(story, change)
+    case change
+    when 'approve'
+      story.approve!
+    when 'reject'
+      story.reject!
+    else
+      false
+    end
+  end
+
+  def story_update_params
+    params.require(:story).permit(:state)
+  end
 
   def story_params
     params.require(:story).permit(:stakeholder, :the_ask, :reasoning, :error_expectation, :confirmation_flow)

--- a/app/models/concerns/story_state_concern.rb
+++ b/app/models/concerns/story_state_concern.rb
@@ -1,0 +1,37 @@
+module StoryStateConcern
+  extend ActiveSupport::Concern
+
+  included do
+    include AASM
+    enum state: {submitted: 0, approved: 1, rejected: 2}
+
+    aasm column: :state, enum: true do
+      state :submitted, initial: true
+      state :approved
+      state :rejected
+
+      event :approve, before: :send_to_tracker! do
+        transitions from: :submitted, to: :approved
+      end
+
+      event :reject do
+        transitions from: :submitted, to: :rejected
+      end
+    end
+  end
+
+  def send_to_tracker!
+    story = user.connection.create_story(tracker_params_hash)
+    if story.id.present?
+      self.update_attribute(:external_ref, story.id)
+    end
+  rescue TrackerApi::Error
+    false
+  end
+
+private
+
+  def tracker_params_hash
+    { name: name, description: description, after_id: after_id }
+  end
+end

--- a/app/models/story_formatter.rb
+++ b/app/models/story_formatter.rb
@@ -29,7 +29,6 @@ class StoryFormatter
 )
   end
 
-
   def as_params
     p = { description: body, name: name}
     if self.after_id.present?

--- a/app/models/tracker_project.rb
+++ b/app/models/tracker_project.rb
@@ -1,6 +1,4 @@
 class TrackerProject
-  # cattr_accessor :api_token
-
   attr_accessor :project_id, :api_token
 
   def initialize(project_id: nil, api_token: nil)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -35,6 +35,14 @@ class User < ActiveRecord::Base
     api_key.present?
   end
 
+  def connection
+    @connection ||= if has_api_key?
+                      TrackerProject.new(api_token: api_key)
+                    else
+                      TrackerProject.new
+                    end
+  end
+
 protected
 
   def api_key_can_access_project

--- a/app/policies/story_policy.rb
+++ b/app/policies/story_policy.rb
@@ -6,6 +6,10 @@ class StoryPolicy
     @story = story
   end
 
+  def index?
+    user.admin?
+  end
+
   def create?
     user.regular_user? or user.admin?
   end

--- a/app/policies/story_policy.rb
+++ b/app/policies/story_policy.rb
@@ -13,4 +13,8 @@ class StoryPolicy
   def create?
     user.regular_user? or user.admin?
   end
+
+  def update?
+    user.admin?
+  end
 end

--- a/app/views/stories/_story.html.haml
+++ b/app/views/stories/_story.html.haml
@@ -13,3 +13,10 @@
       .description
         :markdown
           #{story.description}
+      .actions
+        = form_for story, data: {confirm: 'Are you sure?'} do |f|
+          = f.hidden_field :state, value: 'approve'
+          = f.submit 'Approve'
+        = form_for story, data: {confirm: 'Are you sure?'} do |f|
+          = f.hidden_field :state, value: 'reject'
+          = f.submit 'Reject'

--- a/app/views/stories/_story.html.haml
+++ b/app/views/stories/_story.html.haml
@@ -1,10 +1,15 @@
 .story
-  .type
-    = story_type_icon(story.story_type)
-  .name
-    = story.name
-    -# - if requested_by_user?(story)
-      %span story was requested by a fellow user
-  .risk= calculate_risk(story.estimate)
-  .state{class: story.current_state, title: "Current State: #{story.current_state.titleize}"}
-
+  .row
+    .type
+      = story_type_icon(story.story_type)
+    .name
+      = story.name
+      -# - if requested_by_user?(story)
+        %span story was requested by a fellow user
+    .risk= calculate_risk(story.estimate)
+    .state{class: story.current_state, title: "Current State: #{story.current_state.titleize}"}
+  - if show_description ||= false
+    .row
+      .description
+        :markdown
+          #{story.description}

--- a/app/views/stories/index.html.haml
+++ b/app/views/stories/index.html.haml
@@ -1,0 +1,4 @@
+%h2 Stories submitted for review
+
+%section.stories
+  = render partial: 'story', collection: @stories, locals: {show_description: true}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ Rails.application.routes.draw do
     resources :stories, only: [:new, :create], controller: 'iteration_stories'
   end
 
-  resources :stories, only: [:new, :create]
+  resources :stories, only: [:index, :new, :create]
 
   # resource :user, only: [:show, :edit, :update]
   get '/account', to: 'users#show'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ Rails.application.routes.draw do
     resources :stories, only: [:new, :create], controller: 'iteration_stories'
   end
 
-  resources :stories, only: [:index, :new, :create]
+  resources :stories, only: [:index, :new, :create, :update]
 
   # resource :user, only: [:show, :edit, :update]
   get '/account', to: 'users#show'

--- a/db/migrate/20150727201910_add_state_to_stories.rb
+++ b/db/migrate/20150727201910_add_state_to_stories.rb
@@ -1,0 +1,5 @@
+class AddStateToStories < ActiveRecord::Migration
+  def change
+    add_column :stories, :state, :integer, default: 0, null: false
+  end
+end

--- a/db/migrate/20150728140403_add_story_details_to_stories.rb
+++ b/db/migrate/20150728140403_add_story_details_to_stories.rb
@@ -1,0 +1,9 @@
+class AddStoryDetailsToStories < ActiveRecord::Migration
+  def change
+    change_table :stories do |t|
+      t.string :name
+      t.string :after_id
+      t.text :description
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150725233256) do
+ActiveRecord::Schema.define(version: 20150728140403) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -32,6 +32,10 @@ ActiveRecord::Schema.define(version: 20150725233256) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.boolean  "subscribe",    default: true, null: false
+    t.integer  "state",        default: 0,    null: false
+    t.string   "name"
+    t.string   "after_id"
+    t.text     "description"
   end
 
   add_index "stories", ["user_id"], name: "index_stories_on_user_id", using: :btree

--- a/spec/cassettes/Propose_New_Story/as_a_regular_user/filling_out_the_form.yml
+++ b/spec/cassettes/Propose_New_Story/as_a_regular_user/filling_out_the_form.yml
@@ -938,4 +938,133 @@ http_interactions:
         Criteria\n\n* \n* \n","current_state":"unscheduled","requested_by_id":379075,"project_id":<TRACKERPROJECT>,"url":"https://www.pivotaltracker.com/story/show/99852722","owner_ids":[],"labels":[]}'
     http_version: 
   recorded_at: Sun, 26 Jul 2015 02:14:54 GMT
+- request:
+    method: get
+    uri: https://www.pivotaltracker.com/services/v5/projects/<TRACKERPROJECT>/stories/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Ruby/2.2.2 (x86_64-darwin14; ruby) TrackerApi/0.2.10 Faraday/0.9.1
+      X-Trackertoken:
+      - "<TRACKERAPITOKEN>"
+  response:
+    status:
+      code: 403
+      message: ''
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Status:
+      - 403 Forbidden
+      X-Ua-Compatible:
+      - IE=Edge,chrome=1
+      Cache-Control:
+      - no-cache
+      X-Request-Id:
+      - a288586574fd672c8d1392df8747a613
+      X-Runtime:
+      - '0.017760'
+      Date:
+      - Tue, 28 Jul 2015 14:25:14 GMT
+      X-Rack-Cache:
+      - miss
+      X-Powered-By:
+      - Phusion Passenger 4.0.41
+      Server:
+      - nginx/1.6.0 + Phusion Passenger 4.0.41
+    body:
+      encoding: UTF-8
+      string: '{"code":"invalid_authentication","kind":"error","error":"Invalid authentication
+        credentials were presented.","possible_fix":"Verify that your token value
+        matches what''s shown on your Profile page in Tracker."}'
+    http_version: 
+  recorded_at: Tue, 28 Jul 2015 14:25:17 GMT
+- request:
+    method: get
+    uri: https://www.pivotaltracker.com/services/v5/projects/<TRACKERPROJECT>/stories/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Ruby/2.2.2 (x86_64-darwin14; ruby) TrackerApi/0.2.10 Faraday/0.9.1
+      X-Trackertoken:
+      - "<TRACKERAPITOKEN>"
+  response:
+    status:
+      code: 403
+      message: ''
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Status:
+      - 403 Forbidden
+      X-Ua-Compatible:
+      - IE=Edge,chrome=1
+      Cache-Control:
+      - no-cache
+      X-Request-Id:
+      - b36de5068311beafa4eaa1ad3a3bb73e
+      X-Runtime:
+      - '0.020690'
+      Date:
+      - Tue, 28 Jul 2015 14:25:14 GMT
+      X-Rack-Cache:
+      - miss
+      X-Powered-By:
+      - Phusion Passenger 4.0.41
+      Server:
+      - nginx/1.6.0 + Phusion Passenger 4.0.41
+    body:
+      encoding: UTF-8
+      string: '{"code":"invalid_authentication","kind":"error","error":"Invalid authentication
+        credentials were presented.","possible_fix":"Verify that your token value
+        matches what''s shown on your Profile page in Tracker."}'
+    http_version: 
+  recorded_at: Tue, 28 Jul 2015 14:25:17 GMT
+- request:
+    method: get
+    uri: https://www.pivotaltracker.com/services/v5/projects/<TRACKERPROJECT>/stories/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Ruby/2.2.2 (x86_64-darwin14; ruby) TrackerApi/0.2.10 Faraday/0.9.1
+      X-Trackertoken:
+      - "<TRACKERAPITOKEN>"
+  response:
+    status:
+      code: 403
+      message: ''
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Status:
+      - 403 Forbidden
+      X-Ua-Compatible:
+      - IE=Edge,chrome=1
+      Cache-Control:
+      - no-cache
+      X-Request-Id:
+      - f3f117ab59299df1deb2cc87b782cd2e
+      X-Runtime:
+      - '0.017854'
+      Date:
+      - Tue, 28 Jul 2015 14:25:14 GMT
+      X-Rack-Cache:
+      - miss
+      X-Powered-By:
+      - Phusion Passenger 4.0.41
+      Server:
+      - nginx/1.6.0 + Phusion Passenger 4.0.41
+    body:
+      encoding: UTF-8
+      string: '{"code":"invalid_authentication","kind":"error","error":"Invalid authentication
+        credentials were presented.","possible_fix":"Verify that your token value
+        matches what''s shown on your Profile page in Tracker."}'
+    http_version: 
+  recorded_at: Tue, 28 Jul 2015 14:25:18 GMT
 recorded_with: VCR 2.9.3

--- a/spec/cassettes/Propose_Story_Addition_to_Iteration/as_a_regular_user/filling_out_the_form.yml
+++ b/spec/cassettes/Propose_Story_Addition_to_Iteration/as_a_regular_user/filling_out_the_form.yml
@@ -1146,4 +1146,90 @@ http_interactions:
         Criteria\n\n* \n* \n","current_state":"unstarted","requested_by_id":379075,"project_id":<TRACKERPROJECT>,"url":"https://www.pivotaltracker.com/story/show/99852954","owner_ids":[],"labels":[]}'
     http_version: 
   recorded_at: Sun, 26 Jul 2015 02:58:49 GMT
+- request:
+    method: get
+    uri: https://www.pivotaltracker.com/services/v5/projects/<TRACKERPROJECT>/stories/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Ruby/2.2.2 (x86_64-darwin14; ruby) TrackerApi/0.2.10 Faraday/0.9.1
+      X-Trackertoken:
+      - "<TRACKERAPITOKEN>"
+  response:
+    status:
+      code: 403
+      message: ''
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Status:
+      - 403 Forbidden
+      X-Ua-Compatible:
+      - IE=Edge,chrome=1
+      Cache-Control:
+      - no-cache
+      X-Request-Id:
+      - d6622e21e196d944d1bea5ed407391ce
+      X-Runtime:
+      - '0.016398'
+      Date:
+      - Tue, 28 Jul 2015 14:25:11 GMT
+      X-Rack-Cache:
+      - miss
+      X-Powered-By:
+      - Phusion Passenger 4.0.41
+      Server:
+      - nginx/1.6.0 + Phusion Passenger 4.0.41
+    body:
+      encoding: UTF-8
+      string: '{"code":"invalid_authentication","kind":"error","error":"Invalid authentication
+        credentials were presented.","possible_fix":"Verify that your token value
+        matches what''s shown on your Profile page in Tracker."}'
+    http_version: 
+  recorded_at: Tue, 28 Jul 2015 14:25:14 GMT
+- request:
+    method: get
+    uri: https://www.pivotaltracker.com/services/v5/projects/<TRACKERPROJECT>/stories/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Ruby/2.2.2 (x86_64-darwin14; ruby) TrackerApi/0.2.10 Faraday/0.9.1
+      X-Trackertoken:
+      - "<TRACKERAPITOKEN>"
+  response:
+    status:
+      code: 403
+      message: ''
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Status:
+      - 403 Forbidden
+      X-Ua-Compatible:
+      - IE=Edge,chrome=1
+      Cache-Control:
+      - no-cache
+      X-Request-Id:
+      - 16aaa0f993ea0fc0bca328960ec733ec
+      X-Runtime:
+      - '0.016733'
+      Date:
+      - Tue, 28 Jul 2015 14:25:11 GMT
+      X-Rack-Cache:
+      - miss
+      X-Powered-By:
+      - Phusion Passenger 4.0.41
+      Server:
+      - nginx/1.6.0 + Phusion Passenger 4.0.41
+    body:
+      encoding: UTF-8
+      string: '{"code":"invalid_authentication","kind":"error","error":"Invalid authentication
+        credentials were presented.","possible_fix":"Verify that your token value
+        matches what''s shown on your Profile page in Tracker."}'
+    http_version: 
+  recorded_at: Tue, 28 Jul 2015 14:25:15 GMT
 recorded_with: VCR 2.9.3

--- a/spec/cassettes/Story/states/_approved/can_be_transitioned_from_submitted.yml
+++ b/spec/cassettes/Story/states/_approved/can_be_transitioned_from_submitted.yml
@@ -1,0 +1,46 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://www.pivotaltracker.com/services/v5/projects/<TRACKERPROJECT>
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Ruby/2.2.2 (x86_64-darwin14; ruby) TrackerApi/0.2.10 Faraday/0.9.1
+      X-Trackertoken:
+      - "<TRACKERAPITOKEN>"
+  response:
+    status:
+      code: 403
+      message: ''
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Status:
+      - 403 Forbidden
+      X-Ua-Compatible:
+      - IE=Edge,chrome=1
+      Cache-Control:
+      - no-cache
+      X-Request-Id:
+      - 601ca798cc61e624c54d6ebea02db829
+      X-Runtime:
+      - '0.014571'
+      Date:
+      - Tue, 28 Jul 2015 14:31:14 GMT
+      X-Rack-Cache:
+      - miss
+      X-Powered-By:
+      - Phusion Passenger 4.0.41
+      Server:
+      - nginx/1.6.0 + Phusion Passenger 4.0.41
+    body:
+      encoding: UTF-8
+      string: '{"code":"invalid_authentication","kind":"error","error":"Invalid authentication
+        credentials were presented.","possible_fix":"Verify that your token value
+        matches what''s shown on your Profile page in Tracker."}'
+    http_version: 
+  recorded_at: Tue, 28 Jul 2015 14:31:17 GMT
+recorded_with: VCR 2.9.3

--- a/spec/cassettes/Story/states/_approved/can_be_transitioned_from_submitted.yml
+++ b/spec/cassettes/Story/states/_approved/can_be_transitioned_from_submitted.yml
@@ -13,34 +13,98 @@ http_interactions:
       - "<TRACKERAPITOKEN>"
   response:
     status:
-      code: 403
+      code: 200
       message: ''
     headers:
       Content-Type:
       - application/json; charset=utf-8
       Status:
-      - 403 Forbidden
+      - 200 OK
+      X-Tracker-Project-Version:
+      - '60'
       X-Ua-Compatible:
       - IE=Edge,chrome=1
+      Etag:
+      - '"54ff79786816fdb6c6aecb294e18cd28"'
       Cache-Control:
-      - no-cache
+      - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 601ca798cc61e624c54d6ebea02db829
+      - 3fb2b2ada810025d554574e4dcbd9bf8
       X-Runtime:
-      - '0.014571'
+      - '0.062576'
       Date:
-      - Tue, 28 Jul 2015 14:31:14 GMT
+      - Wed, 29 Jul 2015 14:48:11 GMT
       X-Rack-Cache:
       - miss
       X-Powered-By:
       - Phusion Passenger 4.0.41
       Server:
       - nginx/1.6.0 + Phusion Passenger 4.0.41
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Credentials:
+      - 'false'
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, DELETE, OPTIONS
+      Access-Control-Allow-Headers:
+      - X-TrackerToken,DNT,X-Mx-ReqToken,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,X-Tracker-Warn-Unless-Project-Version-Is
+      X-Tracker-Client-Pinger-Interval:
+      - '12'
     body:
       encoding: UTF-8
-      string: '{"code":"invalid_authentication","kind":"error","error":"Invalid authentication
-        credentials were presented.","possible_fix":"Verify that your token value
-        matches what''s shown on your Profile page in Tracker."}'
+      string: '{"id":<TRACKERPROJECT>,"kind":"project","name":"My Sample Project","version":60,"iteration_length":1,"week_start_day":"Monday","point_scale":"0,1,2,3","point_scale_is_custom":false,"bugs_and_chores_are_estimatable":false,"automatic_planning":true,"enable_tasks":true,"time_zone":{"kind":"time_zone","olson_name":"Etc/UTC","offset":"+00:00"},"velocity_averaged_over":3,"number_of_done_iterations_to_show":12,"has_google_domain":false,"profile_content":"This
+        is a demo project, created by Tracker, with example stories for a simple shopping
+        web site.","enable_incoming_emails":true,"initial_velocity":10,"public":false,"atom_enabled":false,"project_type":"demo","start_time":"2015-06-22T00:00:00Z","created_at":"2015-07-08T18:57:11Z","updated_at":"2015-07-08T19:01:19Z","account_id":774272,"current_iteration_number":6,"enable_following":true}'
     http_version: 
-  recorded_at: Tue, 28 Jul 2015 14:31:17 GMT
+  recorded_at: Wed, 29 Jul 2015 14:48:10 GMT
+- request:
+    method: post
+    uri: https://www.pivotaltracker.com/services/v5/projects/<TRACKERPROJECT>/stories
+    body:
+      encoding: UTF-8
+      string: '{"name":"As a customer, I want foo bar","description":"As an boss,
+        I want another drink, so that I get drunk","after_id":null}'
+    headers:
+      User-Agent:
+      - Ruby/2.2.2 (x86_64-darwin14; ruby) TrackerApi/0.2.10 Faraday/0.9.1
+      X-Trackertoken:
+      - "<TRACKERAPITOKEN>"
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 400
+      message: ''
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Status:
+      - 400 Bad Request
+      X-Ua-Compatible:
+      - IE=Edge,chrome=1
+      Cache-Control:
+      - no-cache
+      X-Request-Id:
+      - 0cafb18337fe023e85a888d5b15aa93f
+      X-Runtime:
+      - '0.215641'
+      Date:
+      - Wed, 29 Jul 2015 14:48:11 GMT
+      X-Rack-Cache:
+      - invalidate, pass
+      X-Powered-By:
+      - Phusion Passenger 4.0.41
+      Server:
+      - nginx/1.6.0 + Phusion Passenger 4.0.41
+    body:
+      encoding: UTF-8
+      string: '{"code":"invalid_parameter","kind":"error","error":"One or more request
+        parameters was missing or invalid.","requirement":"Command parameters that
+        directly set properties of resources must be identical to the result value.","general_problem":"Got
+        bad values for the following parameter(s):  none of the supplied object-move
+        parameters match the generated results (''after_id'' parameter was  but result
+        was 98677188)","possible_fix":"Normalize the parameter values before sending
+        them to the server."}'
+    http_version: 
+  recorded_at: Wed, 29 Jul 2015 14:48:11 GMT
 recorded_with: VCR 2.9.3

--- a/spec/cassettes/Story/states/_approved/cannot_be_transitioned_from_rejected.yml
+++ b/spec/cassettes/Story/states/_approved/cannot_be_transitioned_from_rejected.yml
@@ -1,0 +1,46 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://www.pivotaltracker.com/services/v5/projects/<TRACKERPROJECT>
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Ruby/2.2.2 (x86_64-darwin14; ruby) TrackerApi/0.2.10 Faraday/0.9.1
+      X-Trackertoken:
+      - "<TRACKERAPITOKEN>"
+  response:
+    status:
+      code: 403
+      message: ''
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Status:
+      - 403 Forbidden
+      X-Ua-Compatible:
+      - IE=Edge,chrome=1
+      Cache-Control:
+      - no-cache
+      X-Request-Id:
+      - ee626c7d4ab0a430698b007d344e6337
+      X-Runtime:
+      - '0.017812'
+      Date:
+      - Tue, 28 Jul 2015 14:31:13 GMT
+      X-Rack-Cache:
+      - miss
+      X-Powered-By:
+      - Phusion Passenger 4.0.41
+      Server:
+      - nginx/1.6.0 + Phusion Passenger 4.0.41
+    body:
+      encoding: UTF-8
+      string: '{"code":"invalid_authentication","kind":"error","error":"Invalid authentication
+        credentials were presented.","possible_fix":"Verify that your token value
+        matches what''s shown on your Profile page in Tracker."}'
+    http_version: 
+  recorded_at: Tue, 28 Jul 2015 14:31:17 GMT
+recorded_with: VCR 2.9.3

--- a/spec/cassettes/Story/states/_approved/cannot_be_transitioned_from_rejected.yml
+++ b/spec/cassettes/Story/states/_approved/cannot_be_transitioned_from_rejected.yml
@@ -13,34 +13,98 @@ http_interactions:
       - "<TRACKERAPITOKEN>"
   response:
     status:
-      code: 403
+      code: 200
       message: ''
     headers:
       Content-Type:
       - application/json; charset=utf-8
       Status:
-      - 403 Forbidden
+      - 200 OK
+      X-Tracker-Project-Version:
+      - '60'
       X-Ua-Compatible:
       - IE=Edge,chrome=1
+      Etag:
+      - '"54ff79786816fdb6c6aecb294e18cd28"'
       Cache-Control:
-      - no-cache
+      - max-age=0, private, must-revalidate
       X-Request-Id:
-      - ee626c7d4ab0a430698b007d344e6337
+      - c76f019c3922502a90d58612c1baa771
       X-Runtime:
-      - '0.017812'
+      - '0.051855'
       Date:
-      - Tue, 28 Jul 2015 14:31:13 GMT
+      - Wed, 29 Jul 2015 14:48:10 GMT
       X-Rack-Cache:
       - miss
       X-Powered-By:
       - Phusion Passenger 4.0.41
       Server:
       - nginx/1.6.0 + Phusion Passenger 4.0.41
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Credentials:
+      - 'false'
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, DELETE, OPTIONS
+      Access-Control-Allow-Headers:
+      - X-TrackerToken,DNT,X-Mx-ReqToken,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,X-Tracker-Warn-Unless-Project-Version-Is
+      X-Tracker-Client-Pinger-Interval:
+      - '12'
     body:
       encoding: UTF-8
-      string: '{"code":"invalid_authentication","kind":"error","error":"Invalid authentication
-        credentials were presented.","possible_fix":"Verify that your token value
-        matches what''s shown on your Profile page in Tracker."}'
+      string: '{"id":<TRACKERPROJECT>,"kind":"project","name":"My Sample Project","version":60,"iteration_length":1,"week_start_day":"Monday","point_scale":"0,1,2,3","point_scale_is_custom":false,"bugs_and_chores_are_estimatable":false,"automatic_planning":true,"enable_tasks":true,"time_zone":{"kind":"time_zone","olson_name":"Etc/UTC","offset":"+00:00"},"velocity_averaged_over":3,"number_of_done_iterations_to_show":12,"has_google_domain":false,"profile_content":"This
+        is a demo project, created by Tracker, with example stories for a simple shopping
+        web site.","enable_incoming_emails":true,"initial_velocity":10,"public":false,"atom_enabled":false,"project_type":"demo","start_time":"2015-06-22T00:00:00Z","created_at":"2015-07-08T18:57:11Z","updated_at":"2015-07-08T19:01:19Z","account_id":774272,"current_iteration_number":6,"enable_following":true}'
     http_version: 
-  recorded_at: Tue, 28 Jul 2015 14:31:17 GMT
+  recorded_at: Wed, 29 Jul 2015 14:48:10 GMT
+- request:
+    method: post
+    uri: https://www.pivotaltracker.com/services/v5/projects/<TRACKERPROJECT>/stories
+    body:
+      encoding: UTF-8
+      string: '{"name":"As a customer, I want foo bar","description":"As an boss,
+        I want another drink, so that I get drunk","after_id":null}'
+    headers:
+      User-Agent:
+      - Ruby/2.2.2 (x86_64-darwin14; ruby) TrackerApi/0.2.10 Faraday/0.9.1
+      X-Trackertoken:
+      - "<TRACKERAPITOKEN>"
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 400
+      message: ''
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Status:
+      - 400 Bad Request
+      X-Ua-Compatible:
+      - IE=Edge,chrome=1
+      Cache-Control:
+      - no-cache
+      X-Request-Id:
+      - 1fda6de1260ca54052819f491901e498
+      X-Runtime:
+      - '0.175107'
+      Date:
+      - Wed, 29 Jul 2015 14:48:11 GMT
+      X-Rack-Cache:
+      - invalidate, pass
+      X-Powered-By:
+      - Phusion Passenger 4.0.41
+      Server:
+      - nginx/1.6.0 + Phusion Passenger 4.0.41
+    body:
+      encoding: UTF-8
+      string: '{"code":"invalid_parameter","kind":"error","error":"One or more request
+        parameters was missing or invalid.","requirement":"Command parameters that
+        directly set properties of resources must be identical to the result value.","general_problem":"Got
+        bad values for the following parameter(s):  none of the supplied object-move
+        parameters match the generated results (''after_id'' parameter was  but result
+        was 98677188)","possible_fix":"Normalize the parameter values before sending
+        them to the server."}'
+    http_version: 
+  recorded_at: Wed, 29 Jul 2015 14:48:10 GMT
 recorded_with: VCR 2.9.3

--- a/spec/cassettes/Story_review_process/as_a_non-admin/restricts_regular_users_from_viewing_the_page.yml
+++ b/spec/cassettes/Story_review_process/as_a_non-admin/restricts_regular_users_from_viewing_the_page.yml
@@ -1,0 +1,791 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://www.pivotaltracker.com/services/v5/projects/<TRACKERPROJECT>
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Ruby/2.2.2 (x86_64-darwin14; ruby) TrackerApi/0.2.10 Faraday/0.9.1
+      X-Trackertoken:
+      - "<TRACKERAPITOKEN>"
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Status:
+      - 200 OK
+      X-Tracker-Project-Version:
+      - '60'
+      X-Ua-Compatible:
+      - IE=Edge,chrome=1
+      Etag:
+      - '"54ff79786816fdb6c6aecb294e18cd28"'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 85455ddbad6236572b7373e358a3216e
+      X-Runtime:
+      - '0.050073'
+      Date:
+      - Tue, 28 Jul 2015 17:14:26 GMT
+      X-Rack-Cache:
+      - miss
+      X-Powered-By:
+      - Phusion Passenger 4.0.41
+      Server:
+      - nginx/1.6.0 + Phusion Passenger 4.0.41
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Credentials:
+      - 'false'
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, DELETE, OPTIONS
+      Access-Control-Allow-Headers:
+      - X-TrackerToken,DNT,X-Mx-ReqToken,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,X-Tracker-Warn-Unless-Project-Version-Is
+      X-Tracker-Client-Pinger-Interval:
+      - '12'
+    body:
+      encoding: UTF-8
+      string: '{"id":<TRACKERPROJECT>,"kind":"project","name":"My Sample Project","version":60,"iteration_length":1,"week_start_day":"Monday","point_scale":"0,1,2,3","point_scale_is_custom":false,"bugs_and_chores_are_estimatable":false,"automatic_planning":true,"enable_tasks":true,"time_zone":{"kind":"time_zone","olson_name":"Etc/UTC","offset":"+00:00"},"velocity_averaged_over":3,"number_of_done_iterations_to_show":12,"has_google_domain":false,"profile_content":"This
+        is a demo project, created by Tracker, with example stories for a simple shopping
+        web site.","enable_incoming_emails":true,"initial_velocity":10,"public":false,"atom_enabled":false,"project_type":"demo","start_time":"2015-06-22T00:00:00Z","created_at":"2015-07-08T18:57:11Z","updated_at":"2015-07-08T19:01:19Z","account_id":774272,"current_iteration_number":6,"enable_following":true}'
+    http_version: 
+  recorded_at: Tue, 28 Jul 2015 17:14:29 GMT
+- request:
+    method: get
+    uri: https://www.pivotaltracker.com/services/v5/projects/<TRACKERPROJECT>/iterations?scope=current_backlog
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Ruby/2.2.2 (x86_64-darwin14; ruby) TrackerApi/0.2.10 Faraday/0.9.1
+      X-Trackertoken:
+      - "<TRACKERAPITOKEN>"
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Status:
+      - 200 OK
+      X-Tracker-Project-Version:
+      - '60'
+      X-Tracker-Pagination-Total:
+      - '38'
+      X-Tracker-Pagination-Offset:
+      - '0'
+      X-Tracker-Pagination-Limit:
+      - '10'
+      X-Tracker-Pagination-Returned:
+      - '10'
+      X-Ua-Compatible:
+      - IE=Edge,chrome=1
+      Etag:
+      - '"a45abde516f1b05b1d3db453cf2f1c66"'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 9c58d37bfd4900e84fc392366769bb4e
+      X-Runtime:
+      - '0.035740'
+      Date:
+      - Tue, 28 Jul 2015 17:14:26 GMT
+      X-Rack-Cache:
+      - miss
+      X-Powered-By:
+      - Phusion Passenger 4.0.41
+      Server:
+      - nginx/1.6.0 + Phusion Passenger 4.0.41
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Credentials:
+      - 'false'
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, DELETE, OPTIONS
+      Access-Control-Allow-Headers:
+      - X-TrackerToken,DNT,X-Mx-ReqToken,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,X-Tracker-Warn-Unless-Project-Version-Is
+      X-Tracker-Client-Pinger-Interval:
+      - '12'
+    body:
+      encoding: UTF-8
+      string: '[{"kind":"iteration","number":6,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[{"kind":"story","id":98677104,"project_id":<TRACKERPROJECT>,"name":"Shopper
+        should be able to view contents of shopping cart","description":"Cart icon
+        in top right corner, with a number indicating how many items in cart","story_type":"feature","current_state":"delivered","estimate":2,"requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166940,"project_id":<TRACKERPROJECT>,"name":"cart","created_at":"2015-07-08T18:57:11Z","updated_at":"2015-07-08T18:57:11Z"},{"kind":"label","id":12166936,"project_id":<TRACKERPROJECT>,"name":"shopping","created_at":"2015-07-08T18:57:11Z","updated_at":"2015-07-08T18:57:11Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:11Z","url":"https://www.pivotaltracker.com/story/show/98677104"},{"kind":"story","id":98677106,"project_id":<TRACKERPROJECT>,"name":"Shopper
+        should be able to remove product from shopping cart","story_type":"feature","current_state":"delivered","estimate":1,"requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166940,"project_id":<TRACKERPROJECT>,"name":"cart","created_at":"2015-07-08T18:57:11Z","updated_at":"2015-07-08T18:57:11Z"},{"kind":"label","id":12166936,"project_id":<TRACKERPROJECT>,"name":"shopping","created_at":"2015-07-08T18:57:11Z","updated_at":"2015-07-08T18:57:11Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:11Z","url":"https://www.pivotaltracker.com/story/show/98677106"},{"kind":"story","id":98677108,"project_id":<TRACKERPROJECT>,"name":"Cart
+        manipulation should be AJAXy","story_type":"feature","current_state":"finished","estimate":1,"requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166940,"project_id":<TRACKERPROJECT>,"name":"cart","created_at":"2015-07-08T18:57:11Z","updated_at":"2015-07-08T18:57:11Z"},{"kind":"label","id":12166936,"project_id":<TRACKERPROJECT>,"name":"shopping","created_at":"2015-07-08T18:57:11Z","updated_at":"2015-07-08T18:57:11Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677108"},{"kind":"story","id":98677110,"project_id":<TRACKERPROJECT>,"name":"Some
+        product photos not scaled properly when browsing products","story_type":"bug","current_state":"started","requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166936,"project_id":<TRACKERPROJECT>,"name":"shopping","created_at":"2015-07-08T18:57:11Z","updated_at":"2015-07-08T18:57:11Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677110"},{"kind":"story","id":98677112,"project_id":<TRACKERPROJECT>,"name":"Shopper
+        should be able to recommend a product to a friend","description":"Prompt for
+        email address and personalized message, send email with product details and
+        message","story_type":"feature","current_state":"started","estimate":1,"requested_by_id":379075,"owned_by_id":379075,"owner_ids":[379075],"labels":[{"kind":"label","id":12166936,"project_id":<TRACKERPROJECT>,"name":"shopping","created_at":"2015-07-08T18:57:11Z","updated_at":"2015-07-08T18:57:11Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-21T17:01:29Z","url":"https://www.pivotaltracker.com/story/show/98677112"}],"start":"2015-07-27T00:00:00Z","finish":"2015-08-03T00:00:00Z"},{"kind":"iteration","number":7,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[{"kind":"story","id":98988674,"project_id":<TRACKERPROJECT>,"name":"As
+        a customer, I want slack integration","description":"\nAs an customer, I want
+        slack integration, so that I can stop importing invoices manually.\n\n## Acceptance
+        Criteria\n\n* \n* \n","story_type":"feature","current_state":"unstarted","requested_by_id":379075,"owner_ids":[],"labels":[],"created_at":"2015-07-13T21:28:52Z","updated_at":"2015-07-22T23:10:14Z","url":"https://www.pivotaltracker.com/story/show/98988674"},{"kind":"story","id":99533038,"project_id":<TRACKERPROJECT>,"name":"Adding
+        a new story to the list","description":"This is a new story","story_type":"feature","current_state":"unstarted","requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12276718,"project_id":<TRACKERPROJECT>,"name":"with_label","created_at":"2015-07-21T16:59:37Z","updated_at":"2015-07-21T16:59:37Z"}],"created_at":"2015-07-21T16:59:37Z","updated_at":"2015-07-22T23:06:53Z","url":"https://www.pivotaltracker.com/story/show/99533038"},{"kind":"story","id":99432476,"project_id":<TRACKERPROJECT>,"name":"As
+        a RMS user, I want everything","description":"\nAs an RMS user, I want everything,
+        so that make money.\n\n## Acceptance Criteria\n\n* \n* \n","story_type":"feature","current_state":"unstarted","requested_by_id":379075,"owner_ids":[],"labels":[],"created_at":"2015-07-20T16:23:00Z","updated_at":"2015-07-20T20:08:54Z","url":"https://www.pivotaltracker.com/story/show/99432476"}],"start":"2015-08-03T00:00:00Z","finish":"2015-08-10T00:00:00Z"},{"kind":"iteration","number":8,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[],"start":"2015-08-10T00:00:00Z","finish":"2015-08-17T00:00:00Z"},{"kind":"iteration","number":9,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[{"kind":"story","id":99380320,"project_id":<TRACKERPROJECT>,"name":"As
+        a another customer, I want stuff","description":"\nAs an another customer,
+        I want stuff, so that its very important.\n\n## Acceptance Criteria\n\n* \n*
+        \n","story_type":"feature","current_state":"unstarted","estimate":3,"requested_by_id":379075,"owner_ids":[],"labels":[],"created_at":"2015-07-19T23:38:54Z","updated_at":"2015-07-21T17:02:02Z","url":"https://www.pivotaltracker.com/story/show/99380320"},{"kind":"story","id":98677114,"project_id":<TRACKERPROJECT>,"name":"configure
+        solr for full text searching","story_type":"chore","current_state":"unstarted","requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166942,"project_id":<TRACKERPROJECT>,"name":"search","created_at":"2015-07-08T18:57:12Z","updated_at":"2015-07-08T18:57:12Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677114"},{"kind":"story","id":98688698,"project_id":<TRACKERPROJECT>,"name":"trying
+        to insert after configure solr","story_type":"feature","current_state":"unstarted","requested_by_id":379075,"owner_ids":[],"labels":[],"created_at":"2015-07-08T21:01:30Z","updated_at":"2015-07-08T21:01:30Z","url":"https://www.pivotaltracker.com/story/show/98688698"},{"kind":"story","id":99852954,"project_id":<TRACKERPROJECT>,"name":"As
+        a customer, I want slack integration","description":"\nAs an customer, I want
+        slack integration, so that I can stop importing invoices manually.\n\n## Acceptance
+        Criteria\n\n* \n* \n","story_type":"feature","current_state":"unstarted","requested_by_id":379075,"owner_ids":[],"labels":[],"created_at":"2015-07-26T02:58:46Z","updated_at":"2015-07-26T02:58:46Z","url":"https://www.pivotaltracker.com/story/show/99852954"}],"start":"2015-08-17T00:00:00Z","finish":"2015-08-24T00:00:00Z"},{"kind":"iteration","number":10,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[],"start":"2015-08-24T00:00:00Z","finish":"2015-08-31T00:00:00Z"},{"kind":"iteration","number":11,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[],"start":"2015-08-31T00:00:00Z","finish":"2015-09-07T00:00:00Z"},{"kind":"iteration","number":12,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[{"kind":"story","id":98677116,"project_id":<TRACKERPROJECT>,"name":"Shopper
+        should be able to search for product","description":"One search field, search
+        should look through product name, description, and SKU","story_type":"feature","current_state":"unstarted","estimate":3,"requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166942,"project_id":<TRACKERPROJECT>,"name":"search","created_at":"2015-07-08T18:57:12Z","updated_at":"2015-07-08T18:57:12Z"},{"kind":"label","id":12166936,"project_id":<TRACKERPROJECT>,"name":"shopping","created_at":"2015-07-08T18:57:11Z","updated_at":"2015-07-08T18:57:11Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677116"},{"kind":"story","id":98677118,"project_id":<TRACKERPROJECT>,"name":"Initial
+        demo to investors","story_type":"release","current_state":"unstarted","requested_by_id":379075,"owner_ids":[],"labels":[],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677118"}],"start":"2015-09-07T00:00:00Z","finish":"2015-09-14T00:00:00Z"},{"kind":"iteration","number":13,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[{"kind":"story","id":98677120,"project_id":<TRACKERPROJECT>,"name":"Shopper
+        should be able to enter credit card information and shipping address","story_type":"feature","current_state":"unstarted","estimate":1,"requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166944,"project_id":<TRACKERPROJECT>,"name":"checkout","created_at":"2015-07-08T18:57:12Z","updated_at":"2015-07-08T18:57:12Z"},{"kind":"label","id":12166936,"project_id":<TRACKERPROJECT>,"name":"shopping","created_at":"2015-07-08T18:57:11Z","updated_at":"2015-07-08T18:57:11Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677120"},{"kind":"story","id":98677122,"project_id":<TRACKERPROJECT>,"name":"Integrate
+        with payment gateway","story_type":"chore","current_state":"unstarted","requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166944,"project_id":<TRACKERPROJECT>,"name":"checkout","created_at":"2015-07-08T18:57:12Z","updated_at":"2015-07-08T18:57:12Z"},{"kind":"label","id":12166936,"project_id":<TRACKERPROJECT>,"name":"shopping","created_at":"2015-07-08T18:57:11Z","updated_at":"2015-07-08T18:57:11Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677122"}],"start":"2015-09-14T00:00:00Z","finish":"2015-09-21T00:00:00Z"},{"kind":"iteration","number":14,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[],"start":"2015-09-21T00:00:00Z","finish":"2015-09-28T00:00:00Z"},{"kind":"iteration","number":15,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[],"start":"2015-09-28T00:00:00Z","finish":"2015-10-05T00:00:00Z"}]'
+    http_version: 
+  recorded_at: Tue, 28 Jul 2015 17:14:29 GMT
+- request:
+    method: get
+    uri: https://www.pivotaltracker.com/services/v5/projects/<TRACKERPROJECT>/iterations?limit=10&offset=10&scope=current_backlog
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Ruby/2.2.2 (x86_64-darwin14; ruby) TrackerApi/0.2.10 Faraday/0.9.1
+      X-Trackertoken:
+      - "<TRACKERAPITOKEN>"
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Status:
+      - 200 OK
+      X-Tracker-Project-Version:
+      - '60'
+      X-Tracker-Pagination-Total:
+      - '38'
+      X-Tracker-Pagination-Offset:
+      - '10'
+      X-Tracker-Pagination-Limit:
+      - '10'
+      X-Tracker-Pagination-Returned:
+      - '10'
+      X-Ua-Compatible:
+      - IE=Edge,chrome=1
+      Etag:
+      - '"605d5ce640c91e3bf2a19a2d44f31c02"'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 572fc6948eb1c174ff43bd59805e6297
+      X-Runtime:
+      - '0.038068'
+      Date:
+      - Tue, 28 Jul 2015 17:14:26 GMT
+      X-Rack-Cache:
+      - miss
+      X-Powered-By:
+      - Phusion Passenger 4.0.41
+      Server:
+      - nginx/1.6.0 + Phusion Passenger 4.0.41
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Credentials:
+      - 'false'
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, DELETE, OPTIONS
+      Access-Control-Allow-Headers:
+      - X-TrackerToken,DNT,X-Mx-ReqToken,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,X-Tracker-Warn-Unless-Project-Version-Is
+      X-Tracker-Client-Pinger-Interval:
+      - '12'
+    body:
+      encoding: UTF-8
+      string: '[{"kind":"iteration","number":16,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[{"kind":"story","id":98677124,"project_id":<TRACKERPROJECT>,"name":"When
+        shopper submits order, authorize total product amount from payment gateway","story_type":"feature","current_state":"unstarted","estimate":3,"requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166944,"project_id":<TRACKERPROJECT>,"name":"checkout","created_at":"2015-07-08T18:57:12Z","updated_at":"2015-07-08T18:57:12Z"},{"kind":"label","id":12166946,"project_id":<TRACKERPROJECT>,"name":"needs
+        discussion","created_at":"2015-07-08T18:57:12Z","updated_at":"2015-07-08T18:57:12Z"},{"kind":"label","id":12166936,"project_id":<TRACKERPROJECT>,"name":"shopping","created_at":"2015-07-08T18:57:11Z","updated_at":"2015-07-08T18:57:11Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677124"}],"start":"2015-10-05T00:00:00Z","finish":"2015-10-12T00:00:00Z"},{"kind":"iteration","number":17,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[{"kind":"story","id":98677126,"project_id":<TRACKERPROJECT>,"name":"If
+        system fails to authorize payment amount, display error message to shopper","story_type":"feature","current_state":"unstarted","estimate":1,"requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166944,"project_id":<TRACKERPROJECT>,"name":"checkout","created_at":"2015-07-08T18:57:12Z","updated_at":"2015-07-08T18:57:12Z"},{"kind":"label","id":12166936,"project_id":<TRACKERPROJECT>,"name":"shopping","created_at":"2015-07-08T18:57:11Z","updated_at":"2015-07-08T18:57:11Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677126"}],"start":"2015-10-12T00:00:00Z","finish":"2015-10-19T00:00:00Z"},{"kind":"iteration","number":18,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[{"kind":"story","id":98677128,"project_id":<TRACKERPROJECT>,"name":"If
+        authorization is successful, show order number and confirmation message to
+        shopper","story_type":"feature","current_state":"unstarted","estimate":1,"requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166944,"project_id":<TRACKERPROJECT>,"name":"checkout","created_at":"2015-07-08T18:57:12Z","updated_at":"2015-07-08T18:57:12Z"},{"kind":"label","id":12166936,"project_id":<TRACKERPROJECT>,"name":"shopping","created_at":"2015-07-08T18:57:11Z","updated_at":"2015-07-08T18:57:11Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677128"},{"kind":"story","id":98688754,"project_id":<TRACKERPROJECT>,"name":"Foo
+        Bar 2","story_type":"feature","current_state":"unstarted","requested_by_id":379075,"owner_ids":[],"labels":[],"created_at":"2015-07-08T21:02:19Z","updated_at":"2015-07-08T21:02:19Z","url":"https://www.pivotaltracker.com/story/show/98688754"}],"start":"2015-10-19T00:00:00Z","finish":"2015-10-26T00:00:00Z"},{"kind":"iteration","number":19,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[],"start":"2015-10-26T00:00:00Z","finish":"2015-11-02T00:00:00Z"},{"kind":"iteration","number":20,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[{"kind":"story","id":99260190,"project_id":<TRACKERPROJECT>,"name":"As
+        a fdoo, I want bar","description":"\nAs an fdoo, I want bar, so that baz.\n\n##
+        Acceptance Criteria\n\n* \n* \n","story_type":"feature","current_state":"unstarted","estimate":2,"requested_by_id":379075,"owner_ids":[],"labels":[],"created_at":"2015-07-16T20:49:18Z","updated_at":"2015-07-16T21:00:42Z","url":"https://www.pivotaltracker.com/story/show/99260190"}],"start":"2015-11-02T00:00:00Z","finish":"2015-11-09T00:00:00Z"},{"kind":"iteration","number":21,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[{"kind":"story","id":98677130,"project_id":<TRACKERPROJECT>,"name":"Send
+        notification email of order placement to admin","story_type":"feature","current_state":"unstarted","estimate":1,"requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166934,"project_id":<TRACKERPROJECT>,"name":"admin","created_at":"2015-07-08T18:57:11Z","updated_at":"2015-07-08T18:57:11Z"},{"kind":"label","id":12166944,"project_id":<TRACKERPROJECT>,"name":"checkout","created_at":"2015-07-08T18:57:12Z","updated_at":"2015-07-08T18:57:12Z"},{"kind":"label","id":12166936,"project_id":<TRACKERPROJECT>,"name":"shopping","created_at":"2015-07-08T18:57:11Z","updated_at":"2015-07-08T18:57:11Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677130"}],"start":"2015-11-09T00:00:00Z","finish":"2015-11-16T00:00:00Z"},{"kind":"iteration","number":22,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[],"start":"2015-11-16T00:00:00Z","finish":"2015-11-23T00:00:00Z"},{"kind":"iteration","number":23,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[{"kind":"story","id":98677132,"project_id":<TRACKERPROJECT>,"name":"Shopper
+        should be able to check status of order by entering name and order number","story_type":"feature","current_state":"unstarted","estimate":2,"requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166948,"project_id":<TRACKERPROJECT>,"name":"orders","created_at":"2015-07-08T18:57:12Z","updated_at":"2015-07-08T18:57:12Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677132"}],"start":"2015-11-23T00:00:00Z","finish":"2015-11-30T00:00:00Z"},{"kind":"iteration","number":24,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[{"kind":"story","id":98677134,"project_id":<TRACKERPROJECT>,"name":"Shopper
+        should be able to ask question about order","description":"When checking status
+        of order, shopper should have the option to ask a question. This should send
+        email to admin.","story_type":"feature","current_state":"unstarted","estimate":1,"requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166948,"project_id":<TRACKERPROJECT>,"name":"orders","created_at":"2015-07-08T18:57:12Z","updated_at":"2015-07-08T18:57:12Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677134"}],"start":"2015-11-30T00:00:00Z","finish":"2015-12-07T00:00:00Z"},{"kind":"iteration","number":25,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[{"kind":"story","id":98677136,"project_id":<TRACKERPROJECT>,"name":"Admin
+        can review all order questions and send responses to shoppers","story_type":"feature","current_state":"unstarted","estimate":1,"requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166934,"project_id":<TRACKERPROJECT>,"name":"admin","created_at":"2015-07-08T18:57:11Z","updated_at":"2015-07-08T18:57:11Z"},{"kind":"label","id":12166948,"project_id":<TRACKERPROJECT>,"name":"orders","created_at":"2015-07-08T18:57:12Z","updated_at":"2015-07-08T18:57:12Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677136"},{"kind":"story","id":98677138,"project_id":<TRACKERPROJECT>,"name":"Set
+        up Engine Yard production environment","story_type":"chore","current_state":"unstarted","requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166932,"project_id":<TRACKERPROJECT>,"name":"deployment","created_at":"2015-07-08T18:57:11Z","updated_at":"2015-07-08T18:57:11Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677138"},{"kind":"story","id":98677140,"project_id":<TRACKERPROJECT>,"name":"Beta
+        launch","story_type":"release","current_state":"unstarted","deadline":"2015-07-27T00:00:00Z","requested_by_id":379075,"owner_ids":[],"labels":[],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677140"}],"start":"2015-12-07T00:00:00Z","finish":"2015-12-14T00:00:00Z"}]'
+    http_version: 
+  recorded_at: Tue, 28 Jul 2015 17:14:30 GMT
+- request:
+    method: get
+    uri: https://www.pivotaltracker.com/services/v5/projects/<TRACKERPROJECT>/iterations?limit=10&offset=20&scope=current_backlog
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Ruby/2.2.2 (x86_64-darwin14; ruby) TrackerApi/0.2.10 Faraday/0.9.1
+      X-Trackertoken:
+      - "<TRACKERAPITOKEN>"
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Status:
+      - 200 OK
+      X-Tracker-Project-Version:
+      - '60'
+      X-Tracker-Pagination-Total:
+      - '38'
+      X-Tracker-Pagination-Offset:
+      - '20'
+      X-Tracker-Pagination-Limit:
+      - '10'
+      X-Tracker-Pagination-Returned:
+      - '10'
+      X-Ua-Compatible:
+      - IE=Edge,chrome=1
+      Etag:
+      - '"6d672d053b6acbac48e7708ae2286b55"'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 0b536ffbcaafd995204c07b2c31d69af
+      X-Runtime:
+      - '0.037490'
+      Date:
+      - Tue, 28 Jul 2015 17:14:26 GMT
+      X-Rack-Cache:
+      - miss
+      X-Powered-By:
+      - Phusion Passenger 4.0.41
+      Server:
+      - nginx/1.6.0 + Phusion Passenger 4.0.41
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Credentials:
+      - 'false'
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, DELETE, OPTIONS
+      Access-Control-Allow-Headers:
+      - X-TrackerToken,DNT,X-Mx-ReqToken,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,X-Tracker-Warn-Unless-Project-Version-Is
+      X-Tracker-Client-Pinger-Interval:
+      - '12'
+    body:
+      encoding: UTF-8
+      string: '[{"kind":"iteration","number":26,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[],"start":"2015-12-14T00:00:00Z","finish":"2015-12-21T00:00:00Z"},{"kind":"iteration","number":27,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[{"kind":"story","id":98677142,"project_id":<TRACKERPROJECT>,"name":"Shopper
+        should be able to sign up for an account with email address","story_type":"feature","current_state":"unstarted","estimate":2,"requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166950,"project_id":<TRACKERPROJECT>,"name":"signup
+        / signin","created_at":"2015-07-08T18:57:12Z","updated_at":"2015-07-08T18:57:12Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677142"}],"start":"2015-12-21T00:00:00Z","finish":"2015-12-28T00:00:00Z"},{"kind":"iteration","number":28,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[{"kind":"story","id":98677144,"project_id":<TRACKERPROJECT>,"name":"Shopper
+        should be able to reset forgotten password","story_type":"feature","current_state":"unstarted","estimate":1,"requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166950,"project_id":<TRACKERPROJECT>,"name":"signup
+        / signin","created_at":"2015-07-08T18:57:12Z","updated_at":"2015-07-08T18:57:12Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677144"}],"start":"2015-12-28T00:00:00Z","finish":"2016-01-04T00:00:00Z"},{"kind":"iteration","number":29,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[{"kind":"story","id":98677146,"project_id":<TRACKERPROJECT>,"name":"Shopper
+        should be able to log out","story_type":"feature","current_state":"unstarted","estimate":1,"requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166950,"project_id":<TRACKERPROJECT>,"name":"signup
+        / signin","created_at":"2015-07-08T18:57:12Z","updated_at":"2015-07-08T18:57:12Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677146"}],"start":"2016-01-04T00:00:00Z","finish":"2016-01-11T00:00:00Z"},{"kind":"iteration","number":30,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[{"kind":"story","id":98677148,"project_id":<TRACKERPROJECT>,"name":"When
+        checking out, shopper should have the option to sign in to their account","story_type":"feature","current_state":"unstarted","estimate":1,"requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166950,"project_id":<TRACKERPROJECT>,"name":"signup
+        / signin","created_at":"2015-07-08T18:57:12Z","updated_at":"2015-07-08T18:57:12Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677148"}],"start":"2016-01-11T00:00:00Z","finish":"2016-01-18T00:00:00Z"},{"kind":"iteration","number":31,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[{"kind":"story","id":98677150,"project_id":<TRACKERPROJECT>,"name":"Signed
+        in shopper should be able to review order history","description":"Show orders
+        in last 60 days, with link to show older orders","story_type":"feature","current_state":"unstarted","estimate":1,"requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166952,"project_id":<TRACKERPROJECT>,"name":"shopper
+        accounts","created_at":"2015-07-08T18:57:12Z","updated_at":"2015-07-08T18:57:12Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677150"}],"start":"2016-01-18T00:00:00Z","finish":"2016-01-25T00:00:00Z"},{"kind":"iteration","number":32,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[],"start":"2016-01-25T00:00:00Z","finish":"2016-02-01T00:00:00Z"},{"kind":"iteration","number":33,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[{"kind":"story","id":98677152,"project_id":<TRACKERPROJECT>,"name":"Signed
+        in shopper should be able to save credit card and address information used
+        in checkout","description":"Credit card numbers should be stored encrypted","story_type":"feature","current_state":"unstarted","estimate":2,"requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166952,"project_id":<TRACKERPROJECT>,"name":"shopper
+        accounts","created_at":"2015-07-08T18:57:12Z","updated_at":"2015-07-08T18:57:12Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677152"}],"start":"2016-02-01T00:00:00Z","finish":"2016-02-08T00:00:00Z"},{"kind":"iteration","number":34,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[{"kind":"story","id":98677154,"project_id":<TRACKERPROJECT>,"name":"Signed
+        in shopper should be able to save product to favorites","story_type":"feature","current_state":"unstarted","estimate":1,"requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166952,"project_id":<TRACKERPROJECT>,"name":"shopper
+        accounts","created_at":"2015-07-08T18:57:12Z","updated_at":"2015-07-08T18:57:12Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677154"}],"start":"2016-02-08T00:00:00Z","finish":"2016-02-15T00:00:00Z"},{"kind":"iteration","number":35,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[{"kind":"story","id":98677156,"project_id":<TRACKERPROJECT>,"name":"Signed
+        in shopper should be able to review and remove product from favorites","story_type":"feature","current_state":"unstarted","estimate":1,"requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166952,"project_id":<TRACKERPROJECT>,"name":"shopper
+        accounts","created_at":"2015-07-08T18:57:12Z","updated_at":"2015-07-08T18:57:12Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677156"},{"kind":"story","id":98677158,"project_id":<TRACKERPROJECT>,"name":"Provide
+        feedback to designer about look/feel of site","story_type":"chore","current_state":"unstarted","requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166954,"project_id":<TRACKERPROJECT>,"name":"design","created_at":"2015-07-08T18:57:12Z","updated_at":"2015-07-08T18:57:12Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677158"}],"start":"2016-02-15T00:00:00Z","finish":"2016-02-22T00:00:00Z"}]'
+    http_version: 
+  recorded_at: Tue, 28 Jul 2015 17:14:30 GMT
+- request:
+    method: get
+    uri: https://www.pivotaltracker.com/services/v5/projects/<TRACKERPROJECT>/iterations?limit=10&offset=30&scope=current_backlog
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Ruby/2.2.2 (x86_64-darwin14; ruby) TrackerApi/0.2.10 Faraday/0.9.1
+      X-Trackertoken:
+      - "<TRACKERAPITOKEN>"
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Status:
+      - 200 OK
+      X-Tracker-Project-Version:
+      - '60'
+      X-Tracker-Pagination-Total:
+      - '38'
+      X-Tracker-Pagination-Offset:
+      - '30'
+      X-Tracker-Pagination-Limit:
+      - '10'
+      X-Tracker-Pagination-Returned:
+      - '8'
+      X-Ua-Compatible:
+      - IE=Edge,chrome=1
+      Etag:
+      - '"33834fa7c8aa742f6387c9d3c31fd6c5"'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - a4e82465a0643832caa5a02c33ddec17
+      X-Runtime:
+      - '0.041753'
+      Date:
+      - Tue, 28 Jul 2015 17:14:27 GMT
+      X-Rack-Cache:
+      - miss
+      X-Powered-By:
+      - Phusion Passenger 4.0.41
+      Server:
+      - nginx/1.6.0 + Phusion Passenger 4.0.41
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Credentials:
+      - 'false'
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, DELETE, OPTIONS
+      Access-Control-Allow-Headers:
+      - X-TrackerToken,DNT,X-Mx-ReqToken,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,X-Tracker-Warn-Unless-Project-Version-Is
+      X-Tracker-Client-Pinger-Interval:
+      - '12'
+    body:
+      encoding: UTF-8
+      string: '[{"kind":"iteration","number":36,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[],"start":"2016-02-22T00:00:00Z","finish":"2016-02-29T00:00:00Z"},{"kind":"iteration","number":37,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[],"start":"2016-02-29T00:00:00Z","finish":"2016-03-07T00:00:00Z"},{"kind":"iteration","number":38,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[{"kind":"story","id":98677160,"project_id":<TRACKERPROJECT>,"name":"Apply
+        styling to all shopper facing parts of the site, based on assets from designer","story_type":"feature","current_state":"unstarted","estimate":3,"requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166954,"project_id":<TRACKERPROJECT>,"name":"design","created_at":"2015-07-08T18:57:12Z","updated_at":"2015-07-08T18:57:12Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677160"}],"start":"2016-03-07T00:00:00Z","finish":"2016-03-14T00:00:00Z"},{"kind":"iteration","number":39,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[],"start":"2016-03-14T00:00:00Z","finish":"2016-03-21T00:00:00Z"},{"kind":"iteration","number":40,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[{"kind":"story","id":98677162,"project_id":<TRACKERPROJECT>,"name":"Signed
+        in shopper should be able to post product reviews","story_type":"feature","current_state":"unstarted","estimate":2,"requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166956,"project_id":<TRACKERPROJECT>,"name":"user
+        generated content","created_at":"2015-07-08T18:57:12Z","updated_at":"2015-07-08T18:57:12Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677162"}],"start":"2016-03-21T00:00:00Z","finish":"2016-03-28T00:00:00Z"},{"kind":"iteration","number":41,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[{"kind":"story","id":98677164,"project_id":<TRACKERPROJECT>,"name":"Signed
+        in shopper should be able to rate product, by choosing 1-5 stars","story_type":"feature","current_state":"unstarted","estimate":1,"requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166956,"project_id":<TRACKERPROJECT>,"name":"user
+        generated content","created_at":"2015-07-08T18:57:12Z","updated_at":"2015-07-08T18:57:12Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677164"}],"start":"2016-03-28T00:00:00Z","finish":"2016-04-04T00:00:00Z"},{"kind":"iteration","number":42,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[{"kind":"story","id":98677166,"project_id":<TRACKERPROJECT>,"name":"When
+        shopper is browsing products, show average product rating and number of reviews
+        next to each product","story_type":"feature","current_state":"unstarted","estimate":1,"requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166956,"project_id":<TRACKERPROJECT>,"name":"user
+        generated content","created_at":"2015-07-08T18:57:12Z","updated_at":"2015-07-08T18:57:12Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:13Z","url":"https://www.pivotaltracker.com/story/show/98677166"}],"start":"2016-04-04T00:00:00Z","finish":"2016-04-11T00:00:00Z"},{"kind":"iteration","number":43,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[{"kind":"story","id":98677168,"project_id":<TRACKERPROJECT>,"name":"Shopper
+        should be able to read reviews for a product","story_type":"feature","current_state":"unstarted","estimate":1,"requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166956,"project_id":<TRACKERPROJECT>,"name":"user
+        generated content","created_at":"2015-07-08T18:57:12Z","updated_at":"2015-07-08T18:57:12Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:13Z","url":"https://www.pivotaltracker.com/story/show/98677168"},{"kind":"story","id":98677170,"project_id":<TRACKERPROJECT>,"name":"Admin
+        should be able to mark a product as featured","story_type":"feature","current_state":"unstarted","requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166934,"project_id":<TRACKERPROJECT>,"name":"admin","created_at":"2015-07-08T18:57:11Z","updated_at":"2015-07-08T18:57:11Z"},{"kind":"label","id":12166958,"project_id":<TRACKERPROJECT>,"name":"featured
+        products","created_at":"2015-07-08T18:57:13Z","updated_at":"2015-07-08T18:57:13Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:13Z","url":"https://www.pivotaltracker.com/story/show/98677170"},{"kind":"story","id":98677172,"project_id":<TRACKERPROJECT>,"name":"Featured
+        products should appear on the site landing page","story_type":"feature","current_state":"unstarted","requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166958,"project_id":<TRACKERPROJECT>,"name":"featured
+        products","created_at":"2015-07-08T18:57:13Z","updated_at":"2015-07-08T18:57:13Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:13Z","url":"https://www.pivotaltracker.com/story/show/98677172"},{"kind":"story","id":98677174,"project_id":<TRACKERPROJECT>,"name":"Admin
+        should be able to create and edit blog articles","story_type":"feature","current_state":"unstarted","requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166934,"project_id":<TRACKERPROJECT>,"name":"admin","created_at":"2015-07-08T18:57:11Z","updated_at":"2015-07-08T18:57:11Z"},{"kind":"label","id":12166960,"project_id":<TRACKERPROJECT>,"name":"blog","created_at":"2015-07-08T18:57:13Z","updated_at":"2015-07-08T18:57:13Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:13Z","url":"https://www.pivotaltracker.com/story/show/98677174"},{"kind":"story","id":98677176,"project_id":<TRACKERPROJECT>,"name":"Admin
+        should be able to save blog articles in draft mode","story_type":"feature","current_state":"unstarted","requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166934,"project_id":<TRACKERPROJECT>,"name":"admin","created_at":"2015-07-08T18:57:11Z","updated_at":"2015-07-08T18:57:11Z"},{"kind":"label","id":12166960,"project_id":<TRACKERPROJECT>,"name":"blog","created_at":"2015-07-08T18:57:13Z","updated_at":"2015-07-08T18:57:13Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:13Z","url":"https://www.pivotaltracker.com/story/show/98677176"},{"kind":"story","id":98677178,"project_id":<TRACKERPROJECT>,"name":"Published
+        blog articles should appear on the site","story_type":"feature","current_state":"unstarted","requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166960,"project_id":<TRACKERPROJECT>,"name":"blog","created_at":"2015-07-08T18:57:13Z","updated_at":"2015-07-08T18:57:13Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:13Z","url":"https://www.pivotaltracker.com/story/show/98677178"},{"kind":"story","id":98677180,"project_id":<TRACKERPROJECT>,"name":"People
+        should be able to subscribe to blog via RSS and Atom","story_type":"feature","current_state":"unstarted","requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166960,"project_id":<TRACKERPROJECT>,"name":"blog","created_at":"2015-07-08T18:57:13Z","updated_at":"2015-07-08T18:57:13Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:13Z","url":"https://www.pivotaltracker.com/story/show/98677180"},{"kind":"story","id":98677182,"project_id":<TRACKERPROJECT>,"name":"Admin
+        should be able to view monthly sales report","story_type":"feature","current_state":"unstarted","requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166934,"project_id":<TRACKERPROJECT>,"name":"admin","created_at":"2015-07-08T18:57:11Z","updated_at":"2015-07-08T18:57:11Z"},{"kind":"label","id":12166962,"project_id":<TRACKERPROJECT>,"name":"reporting","created_at":"2015-07-08T18:57:13Z","updated_at":"2015-07-08T18:57:13Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:13Z","url":"https://www.pivotaltracker.com/story/show/98677182"},{"kind":"story","id":98677184,"project_id":<TRACKERPROJECT>,"name":"Admin
+        should be able to export orders as CSV file, based on date range and order
+        status","story_type":"feature","current_state":"unstarted","requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166934,"project_id":<TRACKERPROJECT>,"name":"admin","created_at":"2015-07-08T18:57:11Z","updated_at":"2015-07-08T18:57:11Z"},{"kind":"label","id":12166962,"project_id":<TRACKERPROJECT>,"name":"reporting","created_at":"2015-07-08T18:57:13Z","updated_at":"2015-07-08T18:57:13Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:13Z","url":"https://www.pivotaltracker.com/story/show/98677184"},{"kind":"story","id":98677186,"project_id":<TRACKERPROJECT>,"name":"Request
+        higher number of production slices, for scaling","story_type":"chore","current_state":"unstarted","requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166932,"project_id":<TRACKERPROJECT>,"name":"deployment","created_at":"2015-07-08T18:57:11Z","updated_at":"2015-07-08T18:57:11Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:13Z","url":"https://www.pivotaltracker.com/story/show/98677186"},{"kind":"story","id":98677188,"project_id":<TRACKERPROJECT>,"name":"Full
+        production launch","story_type":"release","current_state":"unstarted","requested_by_id":379075,"owner_ids":[],"labels":[],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:13Z","url":"https://www.pivotaltracker.com/story/show/98677188"}],"start":"2016-04-11T00:00:00Z","finish":"2016-04-18T00:00:00Z"}]'
+    http_version: 
+  recorded_at: Tue, 28 Jul 2015 17:14:30 GMT
+- request:
+    method: get
+    uri: https://www.pivotaltracker.com/services/v5/projects/<TRACKERPROJECT>
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Ruby/2.2.2 (x86_64-darwin14; ruby) TrackerApi/0.2.10 Faraday/0.9.1
+      X-Trackertoken:
+      - "<TRACKERAPITOKEN>"
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Status:
+      - 200 OK
+      X-Tracker-Project-Version:
+      - '60'
+      X-Ua-Compatible:
+      - IE=Edge,chrome=1
+      Etag:
+      - '"54ff79786816fdb6c6aecb294e18cd28"'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 1e1a19fb60d1a30915aa5a7aaca7dc68
+      X-Runtime:
+      - '0.050095'
+      Date:
+      - Tue, 28 Jul 2015 17:14:27 GMT
+      X-Rack-Cache:
+      - miss
+      X-Powered-By:
+      - Phusion Passenger 4.0.41
+      Server:
+      - nginx/1.6.0 + Phusion Passenger 4.0.41
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Credentials:
+      - 'false'
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, DELETE, OPTIONS
+      Access-Control-Allow-Headers:
+      - X-TrackerToken,DNT,X-Mx-ReqToken,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,X-Tracker-Warn-Unless-Project-Version-Is
+      X-Tracker-Client-Pinger-Interval:
+      - '12'
+    body:
+      encoding: UTF-8
+      string: '{"id":<TRACKERPROJECT>,"kind":"project","name":"My Sample Project","version":60,"iteration_length":1,"week_start_day":"Monday","point_scale":"0,1,2,3","point_scale_is_custom":false,"bugs_and_chores_are_estimatable":false,"automatic_planning":true,"enable_tasks":true,"time_zone":{"kind":"time_zone","olson_name":"Etc/UTC","offset":"+00:00"},"velocity_averaged_over":3,"number_of_done_iterations_to_show":12,"has_google_domain":false,"profile_content":"This
+        is a demo project, created by Tracker, with example stories for a simple shopping
+        web site.","enable_incoming_emails":true,"initial_velocity":10,"public":false,"atom_enabled":false,"project_type":"demo","start_time":"2015-06-22T00:00:00Z","created_at":"2015-07-08T18:57:11Z","updated_at":"2015-07-08T19:01:19Z","account_id":774272,"current_iteration_number":6,"enable_following":true}'
+    http_version: 
+  recorded_at: Tue, 28 Jul 2015 17:14:31 GMT
+- request:
+    method: get
+    uri: https://www.pivotaltracker.com/services/v5/projects/<TRACKERPROJECT>/iterations?scope=current_backlog
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Ruby/2.2.2 (x86_64-darwin14; ruby) TrackerApi/0.2.10 Faraday/0.9.1
+      X-Trackertoken:
+      - "<TRACKERAPITOKEN>"
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Status:
+      - 200 OK
+      X-Tracker-Project-Version:
+      - '60'
+      X-Tracker-Pagination-Total:
+      - '38'
+      X-Tracker-Pagination-Offset:
+      - '0'
+      X-Tracker-Pagination-Limit:
+      - '10'
+      X-Tracker-Pagination-Returned:
+      - '10'
+      X-Ua-Compatible:
+      - IE=Edge,chrome=1
+      Etag:
+      - '"a45abde516f1b05b1d3db453cf2f1c66"'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 3ba2f98f4428be21ed4419ef9c48e7af
+      X-Runtime:
+      - '0.043779'
+      Date:
+      - Tue, 28 Jul 2015 17:14:28 GMT
+      X-Rack-Cache:
+      - miss
+      X-Powered-By:
+      - Phusion Passenger 4.0.41
+      Server:
+      - nginx/1.6.0 + Phusion Passenger 4.0.41
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Credentials:
+      - 'false'
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, DELETE, OPTIONS
+      Access-Control-Allow-Headers:
+      - X-TrackerToken,DNT,X-Mx-ReqToken,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,X-Tracker-Warn-Unless-Project-Version-Is
+      X-Tracker-Client-Pinger-Interval:
+      - '12'
+    body:
+      encoding: UTF-8
+      string: '[{"kind":"iteration","number":6,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[{"kind":"story","id":98677104,"project_id":<TRACKERPROJECT>,"name":"Shopper
+        should be able to view contents of shopping cart","description":"Cart icon
+        in top right corner, with a number indicating how many items in cart","story_type":"feature","current_state":"delivered","estimate":2,"requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166940,"project_id":<TRACKERPROJECT>,"name":"cart","created_at":"2015-07-08T18:57:11Z","updated_at":"2015-07-08T18:57:11Z"},{"kind":"label","id":12166936,"project_id":<TRACKERPROJECT>,"name":"shopping","created_at":"2015-07-08T18:57:11Z","updated_at":"2015-07-08T18:57:11Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:11Z","url":"https://www.pivotaltracker.com/story/show/98677104"},{"kind":"story","id":98677106,"project_id":<TRACKERPROJECT>,"name":"Shopper
+        should be able to remove product from shopping cart","story_type":"feature","current_state":"delivered","estimate":1,"requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166940,"project_id":<TRACKERPROJECT>,"name":"cart","created_at":"2015-07-08T18:57:11Z","updated_at":"2015-07-08T18:57:11Z"},{"kind":"label","id":12166936,"project_id":<TRACKERPROJECT>,"name":"shopping","created_at":"2015-07-08T18:57:11Z","updated_at":"2015-07-08T18:57:11Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:11Z","url":"https://www.pivotaltracker.com/story/show/98677106"},{"kind":"story","id":98677108,"project_id":<TRACKERPROJECT>,"name":"Cart
+        manipulation should be AJAXy","story_type":"feature","current_state":"finished","estimate":1,"requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166940,"project_id":<TRACKERPROJECT>,"name":"cart","created_at":"2015-07-08T18:57:11Z","updated_at":"2015-07-08T18:57:11Z"},{"kind":"label","id":12166936,"project_id":<TRACKERPROJECT>,"name":"shopping","created_at":"2015-07-08T18:57:11Z","updated_at":"2015-07-08T18:57:11Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677108"},{"kind":"story","id":98677110,"project_id":<TRACKERPROJECT>,"name":"Some
+        product photos not scaled properly when browsing products","story_type":"bug","current_state":"started","requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166936,"project_id":<TRACKERPROJECT>,"name":"shopping","created_at":"2015-07-08T18:57:11Z","updated_at":"2015-07-08T18:57:11Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677110"},{"kind":"story","id":98677112,"project_id":<TRACKERPROJECT>,"name":"Shopper
+        should be able to recommend a product to a friend","description":"Prompt for
+        email address and personalized message, send email with product details and
+        message","story_type":"feature","current_state":"started","estimate":1,"requested_by_id":379075,"owned_by_id":379075,"owner_ids":[379075],"labels":[{"kind":"label","id":12166936,"project_id":<TRACKERPROJECT>,"name":"shopping","created_at":"2015-07-08T18:57:11Z","updated_at":"2015-07-08T18:57:11Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-21T17:01:29Z","url":"https://www.pivotaltracker.com/story/show/98677112"}],"start":"2015-07-27T00:00:00Z","finish":"2015-08-03T00:00:00Z"},{"kind":"iteration","number":7,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[{"kind":"story","id":98988674,"project_id":<TRACKERPROJECT>,"name":"As
+        a customer, I want slack integration","description":"\nAs an customer, I want
+        slack integration, so that I can stop importing invoices manually.\n\n## Acceptance
+        Criteria\n\n* \n* \n","story_type":"feature","current_state":"unstarted","requested_by_id":379075,"owner_ids":[],"labels":[],"created_at":"2015-07-13T21:28:52Z","updated_at":"2015-07-22T23:10:14Z","url":"https://www.pivotaltracker.com/story/show/98988674"},{"kind":"story","id":99533038,"project_id":<TRACKERPROJECT>,"name":"Adding
+        a new story to the list","description":"This is a new story","story_type":"feature","current_state":"unstarted","requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12276718,"project_id":<TRACKERPROJECT>,"name":"with_label","created_at":"2015-07-21T16:59:37Z","updated_at":"2015-07-21T16:59:37Z"}],"created_at":"2015-07-21T16:59:37Z","updated_at":"2015-07-22T23:06:53Z","url":"https://www.pivotaltracker.com/story/show/99533038"},{"kind":"story","id":99432476,"project_id":<TRACKERPROJECT>,"name":"As
+        a RMS user, I want everything","description":"\nAs an RMS user, I want everything,
+        so that make money.\n\n## Acceptance Criteria\n\n* \n* \n","story_type":"feature","current_state":"unstarted","requested_by_id":379075,"owner_ids":[],"labels":[],"created_at":"2015-07-20T16:23:00Z","updated_at":"2015-07-20T20:08:54Z","url":"https://www.pivotaltracker.com/story/show/99432476"}],"start":"2015-08-03T00:00:00Z","finish":"2015-08-10T00:00:00Z"},{"kind":"iteration","number":8,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[],"start":"2015-08-10T00:00:00Z","finish":"2015-08-17T00:00:00Z"},{"kind":"iteration","number":9,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[{"kind":"story","id":99380320,"project_id":<TRACKERPROJECT>,"name":"As
+        a another customer, I want stuff","description":"\nAs an another customer,
+        I want stuff, so that its very important.\n\n## Acceptance Criteria\n\n* \n*
+        \n","story_type":"feature","current_state":"unstarted","estimate":3,"requested_by_id":379075,"owner_ids":[],"labels":[],"created_at":"2015-07-19T23:38:54Z","updated_at":"2015-07-21T17:02:02Z","url":"https://www.pivotaltracker.com/story/show/99380320"},{"kind":"story","id":98677114,"project_id":<TRACKERPROJECT>,"name":"configure
+        solr for full text searching","story_type":"chore","current_state":"unstarted","requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166942,"project_id":<TRACKERPROJECT>,"name":"search","created_at":"2015-07-08T18:57:12Z","updated_at":"2015-07-08T18:57:12Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677114"},{"kind":"story","id":98688698,"project_id":<TRACKERPROJECT>,"name":"trying
+        to insert after configure solr","story_type":"feature","current_state":"unstarted","requested_by_id":379075,"owner_ids":[],"labels":[],"created_at":"2015-07-08T21:01:30Z","updated_at":"2015-07-08T21:01:30Z","url":"https://www.pivotaltracker.com/story/show/98688698"},{"kind":"story","id":99852954,"project_id":<TRACKERPROJECT>,"name":"As
+        a customer, I want slack integration","description":"\nAs an customer, I want
+        slack integration, so that I can stop importing invoices manually.\n\n## Acceptance
+        Criteria\n\n* \n* \n","story_type":"feature","current_state":"unstarted","requested_by_id":379075,"owner_ids":[],"labels":[],"created_at":"2015-07-26T02:58:46Z","updated_at":"2015-07-26T02:58:46Z","url":"https://www.pivotaltracker.com/story/show/99852954"}],"start":"2015-08-17T00:00:00Z","finish":"2015-08-24T00:00:00Z"},{"kind":"iteration","number":10,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[],"start":"2015-08-24T00:00:00Z","finish":"2015-08-31T00:00:00Z"},{"kind":"iteration","number":11,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[],"start":"2015-08-31T00:00:00Z","finish":"2015-09-07T00:00:00Z"},{"kind":"iteration","number":12,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[{"kind":"story","id":98677116,"project_id":<TRACKERPROJECT>,"name":"Shopper
+        should be able to search for product","description":"One search field, search
+        should look through product name, description, and SKU","story_type":"feature","current_state":"unstarted","estimate":3,"requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166942,"project_id":<TRACKERPROJECT>,"name":"search","created_at":"2015-07-08T18:57:12Z","updated_at":"2015-07-08T18:57:12Z"},{"kind":"label","id":12166936,"project_id":<TRACKERPROJECT>,"name":"shopping","created_at":"2015-07-08T18:57:11Z","updated_at":"2015-07-08T18:57:11Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677116"},{"kind":"story","id":98677118,"project_id":<TRACKERPROJECT>,"name":"Initial
+        demo to investors","story_type":"release","current_state":"unstarted","requested_by_id":379075,"owner_ids":[],"labels":[],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677118"}],"start":"2015-09-07T00:00:00Z","finish":"2015-09-14T00:00:00Z"},{"kind":"iteration","number":13,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[{"kind":"story","id":98677120,"project_id":<TRACKERPROJECT>,"name":"Shopper
+        should be able to enter credit card information and shipping address","story_type":"feature","current_state":"unstarted","estimate":1,"requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166944,"project_id":<TRACKERPROJECT>,"name":"checkout","created_at":"2015-07-08T18:57:12Z","updated_at":"2015-07-08T18:57:12Z"},{"kind":"label","id":12166936,"project_id":<TRACKERPROJECT>,"name":"shopping","created_at":"2015-07-08T18:57:11Z","updated_at":"2015-07-08T18:57:11Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677120"},{"kind":"story","id":98677122,"project_id":<TRACKERPROJECT>,"name":"Integrate
+        with payment gateway","story_type":"chore","current_state":"unstarted","requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166944,"project_id":<TRACKERPROJECT>,"name":"checkout","created_at":"2015-07-08T18:57:12Z","updated_at":"2015-07-08T18:57:12Z"},{"kind":"label","id":12166936,"project_id":<TRACKERPROJECT>,"name":"shopping","created_at":"2015-07-08T18:57:11Z","updated_at":"2015-07-08T18:57:11Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677122"}],"start":"2015-09-14T00:00:00Z","finish":"2015-09-21T00:00:00Z"},{"kind":"iteration","number":14,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[],"start":"2015-09-21T00:00:00Z","finish":"2015-09-28T00:00:00Z"},{"kind":"iteration","number":15,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[],"start":"2015-09-28T00:00:00Z","finish":"2015-10-05T00:00:00Z"}]'
+    http_version: 
+  recorded_at: Tue, 28 Jul 2015 17:14:31 GMT
+- request:
+    method: get
+    uri: https://www.pivotaltracker.com/services/v5/projects/<TRACKERPROJECT>/iterations?limit=10&offset=10&scope=current_backlog
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Ruby/2.2.2 (x86_64-darwin14; ruby) TrackerApi/0.2.10 Faraday/0.9.1
+      X-Trackertoken:
+      - "<TRACKERAPITOKEN>"
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Status:
+      - 200 OK
+      X-Tracker-Project-Version:
+      - '60'
+      X-Tracker-Pagination-Total:
+      - '38'
+      X-Tracker-Pagination-Offset:
+      - '10'
+      X-Tracker-Pagination-Limit:
+      - '10'
+      X-Tracker-Pagination-Returned:
+      - '10'
+      X-Ua-Compatible:
+      - IE=Edge,chrome=1
+      Etag:
+      - '"605d5ce640c91e3bf2a19a2d44f31c02"'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - dab2055ed1dc6b3094cc5edaff838161
+      X-Runtime:
+      - '0.063126'
+      Date:
+      - Tue, 28 Jul 2015 17:14:28 GMT
+      X-Rack-Cache:
+      - miss
+      X-Powered-By:
+      - Phusion Passenger 4.0.41
+      Server:
+      - nginx/1.6.0 + Phusion Passenger 4.0.41
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Credentials:
+      - 'false'
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, DELETE, OPTIONS
+      Access-Control-Allow-Headers:
+      - X-TrackerToken,DNT,X-Mx-ReqToken,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,X-Tracker-Warn-Unless-Project-Version-Is
+      X-Tracker-Client-Pinger-Interval:
+      - '12'
+    body:
+      encoding: UTF-8
+      string: '[{"kind":"iteration","number":16,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[{"kind":"story","id":98677124,"project_id":<TRACKERPROJECT>,"name":"When
+        shopper submits order, authorize total product amount from payment gateway","story_type":"feature","current_state":"unstarted","estimate":3,"requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166944,"project_id":<TRACKERPROJECT>,"name":"checkout","created_at":"2015-07-08T18:57:12Z","updated_at":"2015-07-08T18:57:12Z"},{"kind":"label","id":12166946,"project_id":<TRACKERPROJECT>,"name":"needs
+        discussion","created_at":"2015-07-08T18:57:12Z","updated_at":"2015-07-08T18:57:12Z"},{"kind":"label","id":12166936,"project_id":<TRACKERPROJECT>,"name":"shopping","created_at":"2015-07-08T18:57:11Z","updated_at":"2015-07-08T18:57:11Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677124"}],"start":"2015-10-05T00:00:00Z","finish":"2015-10-12T00:00:00Z"},{"kind":"iteration","number":17,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[{"kind":"story","id":98677126,"project_id":<TRACKERPROJECT>,"name":"If
+        system fails to authorize payment amount, display error message to shopper","story_type":"feature","current_state":"unstarted","estimate":1,"requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166944,"project_id":<TRACKERPROJECT>,"name":"checkout","created_at":"2015-07-08T18:57:12Z","updated_at":"2015-07-08T18:57:12Z"},{"kind":"label","id":12166936,"project_id":<TRACKERPROJECT>,"name":"shopping","created_at":"2015-07-08T18:57:11Z","updated_at":"2015-07-08T18:57:11Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677126"}],"start":"2015-10-12T00:00:00Z","finish":"2015-10-19T00:00:00Z"},{"kind":"iteration","number":18,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[{"kind":"story","id":98677128,"project_id":<TRACKERPROJECT>,"name":"If
+        authorization is successful, show order number and confirmation message to
+        shopper","story_type":"feature","current_state":"unstarted","estimate":1,"requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166944,"project_id":<TRACKERPROJECT>,"name":"checkout","created_at":"2015-07-08T18:57:12Z","updated_at":"2015-07-08T18:57:12Z"},{"kind":"label","id":12166936,"project_id":<TRACKERPROJECT>,"name":"shopping","created_at":"2015-07-08T18:57:11Z","updated_at":"2015-07-08T18:57:11Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677128"},{"kind":"story","id":98688754,"project_id":<TRACKERPROJECT>,"name":"Foo
+        Bar 2","story_type":"feature","current_state":"unstarted","requested_by_id":379075,"owner_ids":[],"labels":[],"created_at":"2015-07-08T21:02:19Z","updated_at":"2015-07-08T21:02:19Z","url":"https://www.pivotaltracker.com/story/show/98688754"}],"start":"2015-10-19T00:00:00Z","finish":"2015-10-26T00:00:00Z"},{"kind":"iteration","number":19,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[],"start":"2015-10-26T00:00:00Z","finish":"2015-11-02T00:00:00Z"},{"kind":"iteration","number":20,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[{"kind":"story","id":99260190,"project_id":<TRACKERPROJECT>,"name":"As
+        a fdoo, I want bar","description":"\nAs an fdoo, I want bar, so that baz.\n\n##
+        Acceptance Criteria\n\n* \n* \n","story_type":"feature","current_state":"unstarted","estimate":2,"requested_by_id":379075,"owner_ids":[],"labels":[],"created_at":"2015-07-16T20:49:18Z","updated_at":"2015-07-16T21:00:42Z","url":"https://www.pivotaltracker.com/story/show/99260190"}],"start":"2015-11-02T00:00:00Z","finish":"2015-11-09T00:00:00Z"},{"kind":"iteration","number":21,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[{"kind":"story","id":98677130,"project_id":<TRACKERPROJECT>,"name":"Send
+        notification email of order placement to admin","story_type":"feature","current_state":"unstarted","estimate":1,"requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166934,"project_id":<TRACKERPROJECT>,"name":"admin","created_at":"2015-07-08T18:57:11Z","updated_at":"2015-07-08T18:57:11Z"},{"kind":"label","id":12166944,"project_id":<TRACKERPROJECT>,"name":"checkout","created_at":"2015-07-08T18:57:12Z","updated_at":"2015-07-08T18:57:12Z"},{"kind":"label","id":12166936,"project_id":<TRACKERPROJECT>,"name":"shopping","created_at":"2015-07-08T18:57:11Z","updated_at":"2015-07-08T18:57:11Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677130"}],"start":"2015-11-09T00:00:00Z","finish":"2015-11-16T00:00:00Z"},{"kind":"iteration","number":22,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[],"start":"2015-11-16T00:00:00Z","finish":"2015-11-23T00:00:00Z"},{"kind":"iteration","number":23,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[{"kind":"story","id":98677132,"project_id":<TRACKERPROJECT>,"name":"Shopper
+        should be able to check status of order by entering name and order number","story_type":"feature","current_state":"unstarted","estimate":2,"requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166948,"project_id":<TRACKERPROJECT>,"name":"orders","created_at":"2015-07-08T18:57:12Z","updated_at":"2015-07-08T18:57:12Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677132"}],"start":"2015-11-23T00:00:00Z","finish":"2015-11-30T00:00:00Z"},{"kind":"iteration","number":24,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[{"kind":"story","id":98677134,"project_id":<TRACKERPROJECT>,"name":"Shopper
+        should be able to ask question about order","description":"When checking status
+        of order, shopper should have the option to ask a question. This should send
+        email to admin.","story_type":"feature","current_state":"unstarted","estimate":1,"requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166948,"project_id":<TRACKERPROJECT>,"name":"orders","created_at":"2015-07-08T18:57:12Z","updated_at":"2015-07-08T18:57:12Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677134"}],"start":"2015-11-30T00:00:00Z","finish":"2015-12-07T00:00:00Z"},{"kind":"iteration","number":25,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[{"kind":"story","id":98677136,"project_id":<TRACKERPROJECT>,"name":"Admin
+        can review all order questions and send responses to shoppers","story_type":"feature","current_state":"unstarted","estimate":1,"requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166934,"project_id":<TRACKERPROJECT>,"name":"admin","created_at":"2015-07-08T18:57:11Z","updated_at":"2015-07-08T18:57:11Z"},{"kind":"label","id":12166948,"project_id":<TRACKERPROJECT>,"name":"orders","created_at":"2015-07-08T18:57:12Z","updated_at":"2015-07-08T18:57:12Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677136"},{"kind":"story","id":98677138,"project_id":<TRACKERPROJECT>,"name":"Set
+        up Engine Yard production environment","story_type":"chore","current_state":"unstarted","requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166932,"project_id":<TRACKERPROJECT>,"name":"deployment","created_at":"2015-07-08T18:57:11Z","updated_at":"2015-07-08T18:57:11Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677138"},{"kind":"story","id":98677140,"project_id":<TRACKERPROJECT>,"name":"Beta
+        launch","story_type":"release","current_state":"unstarted","deadline":"2015-07-27T00:00:00Z","requested_by_id":379075,"owner_ids":[],"labels":[],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677140"}],"start":"2015-12-07T00:00:00Z","finish":"2015-12-14T00:00:00Z"}]'
+    http_version: 
+  recorded_at: Tue, 28 Jul 2015 17:14:31 GMT
+- request:
+    method: get
+    uri: https://www.pivotaltracker.com/services/v5/projects/<TRACKERPROJECT>/iterations?limit=10&offset=20&scope=current_backlog
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Ruby/2.2.2 (x86_64-darwin14; ruby) TrackerApi/0.2.10 Faraday/0.9.1
+      X-Trackertoken:
+      - "<TRACKERAPITOKEN>"
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Status:
+      - 200 OK
+      X-Tracker-Project-Version:
+      - '60'
+      X-Tracker-Pagination-Total:
+      - '38'
+      X-Tracker-Pagination-Offset:
+      - '20'
+      X-Tracker-Pagination-Limit:
+      - '10'
+      X-Tracker-Pagination-Returned:
+      - '10'
+      X-Ua-Compatible:
+      - IE=Edge,chrome=1
+      Etag:
+      - '"6d672d053b6acbac48e7708ae2286b55"'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - e52d61994afaee0e5a908714557c031e
+      X-Runtime:
+      - '0.044836'
+      Date:
+      - Tue, 28 Jul 2015 17:14:28 GMT
+      X-Rack-Cache:
+      - miss
+      X-Powered-By:
+      - Phusion Passenger 4.0.41
+      Server:
+      - nginx/1.6.0 + Phusion Passenger 4.0.41
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Credentials:
+      - 'false'
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, DELETE, OPTIONS
+      Access-Control-Allow-Headers:
+      - X-TrackerToken,DNT,X-Mx-ReqToken,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,X-Tracker-Warn-Unless-Project-Version-Is
+      X-Tracker-Client-Pinger-Interval:
+      - '12'
+    body:
+      encoding: UTF-8
+      string: '[{"kind":"iteration","number":26,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[],"start":"2015-12-14T00:00:00Z","finish":"2015-12-21T00:00:00Z"},{"kind":"iteration","number":27,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[{"kind":"story","id":98677142,"project_id":<TRACKERPROJECT>,"name":"Shopper
+        should be able to sign up for an account with email address","story_type":"feature","current_state":"unstarted","estimate":2,"requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166950,"project_id":<TRACKERPROJECT>,"name":"signup
+        / signin","created_at":"2015-07-08T18:57:12Z","updated_at":"2015-07-08T18:57:12Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677142"}],"start":"2015-12-21T00:00:00Z","finish":"2015-12-28T00:00:00Z"},{"kind":"iteration","number":28,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[{"kind":"story","id":98677144,"project_id":<TRACKERPROJECT>,"name":"Shopper
+        should be able to reset forgotten password","story_type":"feature","current_state":"unstarted","estimate":1,"requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166950,"project_id":<TRACKERPROJECT>,"name":"signup
+        / signin","created_at":"2015-07-08T18:57:12Z","updated_at":"2015-07-08T18:57:12Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677144"}],"start":"2015-12-28T00:00:00Z","finish":"2016-01-04T00:00:00Z"},{"kind":"iteration","number":29,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[{"kind":"story","id":98677146,"project_id":<TRACKERPROJECT>,"name":"Shopper
+        should be able to log out","story_type":"feature","current_state":"unstarted","estimate":1,"requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166950,"project_id":<TRACKERPROJECT>,"name":"signup
+        / signin","created_at":"2015-07-08T18:57:12Z","updated_at":"2015-07-08T18:57:12Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677146"}],"start":"2016-01-04T00:00:00Z","finish":"2016-01-11T00:00:00Z"},{"kind":"iteration","number":30,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[{"kind":"story","id":98677148,"project_id":<TRACKERPROJECT>,"name":"When
+        checking out, shopper should have the option to sign in to their account","story_type":"feature","current_state":"unstarted","estimate":1,"requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166950,"project_id":<TRACKERPROJECT>,"name":"signup
+        / signin","created_at":"2015-07-08T18:57:12Z","updated_at":"2015-07-08T18:57:12Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677148"}],"start":"2016-01-11T00:00:00Z","finish":"2016-01-18T00:00:00Z"},{"kind":"iteration","number":31,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[{"kind":"story","id":98677150,"project_id":<TRACKERPROJECT>,"name":"Signed
+        in shopper should be able to review order history","description":"Show orders
+        in last 60 days, with link to show older orders","story_type":"feature","current_state":"unstarted","estimate":1,"requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166952,"project_id":<TRACKERPROJECT>,"name":"shopper
+        accounts","created_at":"2015-07-08T18:57:12Z","updated_at":"2015-07-08T18:57:12Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677150"}],"start":"2016-01-18T00:00:00Z","finish":"2016-01-25T00:00:00Z"},{"kind":"iteration","number":32,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[],"start":"2016-01-25T00:00:00Z","finish":"2016-02-01T00:00:00Z"},{"kind":"iteration","number":33,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[{"kind":"story","id":98677152,"project_id":<TRACKERPROJECT>,"name":"Signed
+        in shopper should be able to save credit card and address information used
+        in checkout","description":"Credit card numbers should be stored encrypted","story_type":"feature","current_state":"unstarted","estimate":2,"requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166952,"project_id":<TRACKERPROJECT>,"name":"shopper
+        accounts","created_at":"2015-07-08T18:57:12Z","updated_at":"2015-07-08T18:57:12Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677152"}],"start":"2016-02-01T00:00:00Z","finish":"2016-02-08T00:00:00Z"},{"kind":"iteration","number":34,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[{"kind":"story","id":98677154,"project_id":<TRACKERPROJECT>,"name":"Signed
+        in shopper should be able to save product to favorites","story_type":"feature","current_state":"unstarted","estimate":1,"requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166952,"project_id":<TRACKERPROJECT>,"name":"shopper
+        accounts","created_at":"2015-07-08T18:57:12Z","updated_at":"2015-07-08T18:57:12Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677154"}],"start":"2016-02-08T00:00:00Z","finish":"2016-02-15T00:00:00Z"},{"kind":"iteration","number":35,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[{"kind":"story","id":98677156,"project_id":<TRACKERPROJECT>,"name":"Signed
+        in shopper should be able to review and remove product from favorites","story_type":"feature","current_state":"unstarted","estimate":1,"requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166952,"project_id":<TRACKERPROJECT>,"name":"shopper
+        accounts","created_at":"2015-07-08T18:57:12Z","updated_at":"2015-07-08T18:57:12Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677156"},{"kind":"story","id":98677158,"project_id":<TRACKERPROJECT>,"name":"Provide
+        feedback to designer about look/feel of site","story_type":"chore","current_state":"unstarted","requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166954,"project_id":<TRACKERPROJECT>,"name":"design","created_at":"2015-07-08T18:57:12Z","updated_at":"2015-07-08T18:57:12Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677158"}],"start":"2016-02-15T00:00:00Z","finish":"2016-02-22T00:00:00Z"}]'
+    http_version: 
+  recorded_at: Tue, 28 Jul 2015 17:14:31 GMT
+- request:
+    method: get
+    uri: https://www.pivotaltracker.com/services/v5/projects/<TRACKERPROJECT>/iterations?limit=10&offset=30&scope=current_backlog
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Ruby/2.2.2 (x86_64-darwin14; ruby) TrackerApi/0.2.10 Faraday/0.9.1
+      X-Trackertoken:
+      - "<TRACKERAPITOKEN>"
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Status:
+      - 200 OK
+      X-Tracker-Project-Version:
+      - '60'
+      X-Tracker-Pagination-Total:
+      - '38'
+      X-Tracker-Pagination-Offset:
+      - '30'
+      X-Tracker-Pagination-Limit:
+      - '10'
+      X-Tracker-Pagination-Returned:
+      - '8'
+      X-Ua-Compatible:
+      - IE=Edge,chrome=1
+      Etag:
+      - '"33834fa7c8aa742f6387c9d3c31fd6c5"'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 0b9435e53e300eee58fd89d6384a625e
+      X-Runtime:
+      - '0.047810'
+      Date:
+      - Tue, 28 Jul 2015 17:14:28 GMT
+      X-Rack-Cache:
+      - miss
+      X-Powered-By:
+      - Phusion Passenger 4.0.41
+      Server:
+      - nginx/1.6.0 + Phusion Passenger 4.0.41
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Credentials:
+      - 'false'
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, DELETE, OPTIONS
+      Access-Control-Allow-Headers:
+      - X-TrackerToken,DNT,X-Mx-ReqToken,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,X-Tracker-Warn-Unless-Project-Version-Is
+      X-Tracker-Client-Pinger-Interval:
+      - '12'
+    body:
+      encoding: UTF-8
+      string: '[{"kind":"iteration","number":36,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[],"start":"2016-02-22T00:00:00Z","finish":"2016-02-29T00:00:00Z"},{"kind":"iteration","number":37,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[],"start":"2016-02-29T00:00:00Z","finish":"2016-03-07T00:00:00Z"},{"kind":"iteration","number":38,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[{"kind":"story","id":98677160,"project_id":<TRACKERPROJECT>,"name":"Apply
+        styling to all shopper facing parts of the site, based on assets from designer","story_type":"feature","current_state":"unstarted","estimate":3,"requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166954,"project_id":<TRACKERPROJECT>,"name":"design","created_at":"2015-07-08T18:57:12Z","updated_at":"2015-07-08T18:57:12Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677160"}],"start":"2016-03-07T00:00:00Z","finish":"2016-03-14T00:00:00Z"},{"kind":"iteration","number":39,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[],"start":"2016-03-14T00:00:00Z","finish":"2016-03-21T00:00:00Z"},{"kind":"iteration","number":40,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[{"kind":"story","id":98677162,"project_id":<TRACKERPROJECT>,"name":"Signed
+        in shopper should be able to post product reviews","story_type":"feature","current_state":"unstarted","estimate":2,"requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166956,"project_id":<TRACKERPROJECT>,"name":"user
+        generated content","created_at":"2015-07-08T18:57:12Z","updated_at":"2015-07-08T18:57:12Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677162"}],"start":"2016-03-21T00:00:00Z","finish":"2016-03-28T00:00:00Z"},{"kind":"iteration","number":41,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[{"kind":"story","id":98677164,"project_id":<TRACKERPROJECT>,"name":"Signed
+        in shopper should be able to rate product, by choosing 1-5 stars","story_type":"feature","current_state":"unstarted","estimate":1,"requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166956,"project_id":<TRACKERPROJECT>,"name":"user
+        generated content","created_at":"2015-07-08T18:57:12Z","updated_at":"2015-07-08T18:57:12Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677164"}],"start":"2016-03-28T00:00:00Z","finish":"2016-04-04T00:00:00Z"},{"kind":"iteration","number":42,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[{"kind":"story","id":98677166,"project_id":<TRACKERPROJECT>,"name":"When
+        shopper is browsing products, show average product rating and number of reviews
+        next to each product","story_type":"feature","current_state":"unstarted","estimate":1,"requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166956,"project_id":<TRACKERPROJECT>,"name":"user
+        generated content","created_at":"2015-07-08T18:57:12Z","updated_at":"2015-07-08T18:57:12Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:13Z","url":"https://www.pivotaltracker.com/story/show/98677166"}],"start":"2016-04-04T00:00:00Z","finish":"2016-04-11T00:00:00Z"},{"kind":"iteration","number":43,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[{"kind":"story","id":98677168,"project_id":<TRACKERPROJECT>,"name":"Shopper
+        should be able to read reviews for a product","story_type":"feature","current_state":"unstarted","estimate":1,"requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166956,"project_id":<TRACKERPROJECT>,"name":"user
+        generated content","created_at":"2015-07-08T18:57:12Z","updated_at":"2015-07-08T18:57:12Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:13Z","url":"https://www.pivotaltracker.com/story/show/98677168"},{"kind":"story","id":98677170,"project_id":<TRACKERPROJECT>,"name":"Admin
+        should be able to mark a product as featured","story_type":"feature","current_state":"unstarted","requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166934,"project_id":<TRACKERPROJECT>,"name":"admin","created_at":"2015-07-08T18:57:11Z","updated_at":"2015-07-08T18:57:11Z"},{"kind":"label","id":12166958,"project_id":<TRACKERPROJECT>,"name":"featured
+        products","created_at":"2015-07-08T18:57:13Z","updated_at":"2015-07-08T18:57:13Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:13Z","url":"https://www.pivotaltracker.com/story/show/98677170"},{"kind":"story","id":98677172,"project_id":<TRACKERPROJECT>,"name":"Featured
+        products should appear on the site landing page","story_type":"feature","current_state":"unstarted","requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166958,"project_id":<TRACKERPROJECT>,"name":"featured
+        products","created_at":"2015-07-08T18:57:13Z","updated_at":"2015-07-08T18:57:13Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:13Z","url":"https://www.pivotaltracker.com/story/show/98677172"},{"kind":"story","id":98677174,"project_id":<TRACKERPROJECT>,"name":"Admin
+        should be able to create and edit blog articles","story_type":"feature","current_state":"unstarted","requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166934,"project_id":<TRACKERPROJECT>,"name":"admin","created_at":"2015-07-08T18:57:11Z","updated_at":"2015-07-08T18:57:11Z"},{"kind":"label","id":12166960,"project_id":<TRACKERPROJECT>,"name":"blog","created_at":"2015-07-08T18:57:13Z","updated_at":"2015-07-08T18:57:13Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:13Z","url":"https://www.pivotaltracker.com/story/show/98677174"},{"kind":"story","id":98677176,"project_id":<TRACKERPROJECT>,"name":"Admin
+        should be able to save blog articles in draft mode","story_type":"feature","current_state":"unstarted","requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166934,"project_id":<TRACKERPROJECT>,"name":"admin","created_at":"2015-07-08T18:57:11Z","updated_at":"2015-07-08T18:57:11Z"},{"kind":"label","id":12166960,"project_id":<TRACKERPROJECT>,"name":"blog","created_at":"2015-07-08T18:57:13Z","updated_at":"2015-07-08T18:57:13Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:13Z","url":"https://www.pivotaltracker.com/story/show/98677176"},{"kind":"story","id":98677178,"project_id":<TRACKERPROJECT>,"name":"Published
+        blog articles should appear on the site","story_type":"feature","current_state":"unstarted","requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166960,"project_id":<TRACKERPROJECT>,"name":"blog","created_at":"2015-07-08T18:57:13Z","updated_at":"2015-07-08T18:57:13Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:13Z","url":"https://www.pivotaltracker.com/story/show/98677178"},{"kind":"story","id":98677180,"project_id":<TRACKERPROJECT>,"name":"People
+        should be able to subscribe to blog via RSS and Atom","story_type":"feature","current_state":"unstarted","requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166960,"project_id":<TRACKERPROJECT>,"name":"blog","created_at":"2015-07-08T18:57:13Z","updated_at":"2015-07-08T18:57:13Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:13Z","url":"https://www.pivotaltracker.com/story/show/98677180"},{"kind":"story","id":98677182,"project_id":<TRACKERPROJECT>,"name":"Admin
+        should be able to view monthly sales report","story_type":"feature","current_state":"unstarted","requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166934,"project_id":<TRACKERPROJECT>,"name":"admin","created_at":"2015-07-08T18:57:11Z","updated_at":"2015-07-08T18:57:11Z"},{"kind":"label","id":12166962,"project_id":<TRACKERPROJECT>,"name":"reporting","created_at":"2015-07-08T18:57:13Z","updated_at":"2015-07-08T18:57:13Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:13Z","url":"https://www.pivotaltracker.com/story/show/98677182"},{"kind":"story","id":98677184,"project_id":<TRACKERPROJECT>,"name":"Admin
+        should be able to export orders as CSV file, based on date range and order
+        status","story_type":"feature","current_state":"unstarted","requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166934,"project_id":<TRACKERPROJECT>,"name":"admin","created_at":"2015-07-08T18:57:11Z","updated_at":"2015-07-08T18:57:11Z"},{"kind":"label","id":12166962,"project_id":<TRACKERPROJECT>,"name":"reporting","created_at":"2015-07-08T18:57:13Z","updated_at":"2015-07-08T18:57:13Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:13Z","url":"https://www.pivotaltracker.com/story/show/98677184"},{"kind":"story","id":98677186,"project_id":<TRACKERPROJECT>,"name":"Request
+        higher number of production slices, for scaling","story_type":"chore","current_state":"unstarted","requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166932,"project_id":<TRACKERPROJECT>,"name":"deployment","created_at":"2015-07-08T18:57:11Z","updated_at":"2015-07-08T18:57:11Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:13Z","url":"https://www.pivotaltracker.com/story/show/98677186"},{"kind":"story","id":98677188,"project_id":<TRACKERPROJECT>,"name":"Full
+        production launch","story_type":"release","current_state":"unstarted","requested_by_id":379075,"owner_ids":[],"labels":[],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:13Z","url":"https://www.pivotaltracker.com/story/show/98677188"}],"start":"2016-04-11T00:00:00Z","finish":"2016-04-18T00:00:00Z"}]'
+    http_version: 
+  recorded_at: Tue, 28 Jul 2015 17:14:32 GMT
+recorded_with: VCR 2.9.3

--- a/spec/cassettes/Story_review_process/as_an_admin/has_the_ability_to_approve.yml
+++ b/spec/cassettes/Story_review_process/as_an_admin/has_the_ability_to_approve.yml
@@ -29,11 +29,11 @@ http_interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 5ccce4de2d2fe5465b3234f6fdd7019f
+      - 01f6e37a4148999486fa9dc159353a06
       X-Runtime:
-      - '0.041147'
+      - '0.044169'
       Date:
-      - Wed, 29 Jul 2015 14:47:37 GMT
+      - Wed, 29 Jul 2015 14:47:35 GMT
       X-Rack-Cache:
       - miss
       X-Powered-By:
@@ -56,7 +56,7 @@ http_interactions:
         is a demo project, created by Tracker, with example stories for a simple shopping
         web site.","enable_incoming_emails":true,"initial_velocity":10,"public":false,"atom_enabled":false,"project_type":"demo","start_time":"2015-06-22T00:00:00Z","created_at":"2015-07-08T18:57:11Z","updated_at":"2015-07-08T19:01:19Z","account_id":774272,"current_iteration_number":6,"enable_following":true}'
     http_version: 
-  recorded_at: Wed, 29 Jul 2015 14:47:37 GMT
+  recorded_at: Wed, 29 Jul 2015 14:47:34 GMT
 - request:
     method: get
     uri: https://www.pivotaltracker.com/services/v5/projects/<TRACKERPROJECT>/iterations?scope=current_backlog
@@ -94,11 +94,11 @@ http_interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 3247bc71a1f74e9bed17d93ca2d6078b
+      - 104e06e98ec25384788a39f3b673f968
       X-Runtime:
-      - '0.041152'
+      - '0.046632'
       Date:
-      - Wed, 29 Jul 2015 14:47:37 GMT
+      - Wed, 29 Jul 2015 14:47:35 GMT
       X-Rack-Cache:
       - miss
       X-Powered-By:
@@ -146,7 +146,7 @@ http_interactions:
         should be able to enter credit card information and shipping address","story_type":"feature","current_state":"unstarted","estimate":1,"requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166944,"project_id":<TRACKERPROJECT>,"name":"checkout","created_at":"2015-07-08T18:57:12Z","updated_at":"2015-07-08T18:57:12Z"},{"kind":"label","id":12166936,"project_id":<TRACKERPROJECT>,"name":"shopping","created_at":"2015-07-08T18:57:11Z","updated_at":"2015-07-08T18:57:11Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677120"},{"kind":"story","id":98677122,"project_id":<TRACKERPROJECT>,"name":"Integrate
         with payment gateway","story_type":"chore","current_state":"unstarted","requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166944,"project_id":<TRACKERPROJECT>,"name":"checkout","created_at":"2015-07-08T18:57:12Z","updated_at":"2015-07-08T18:57:12Z"},{"kind":"label","id":12166936,"project_id":<TRACKERPROJECT>,"name":"shopping","created_at":"2015-07-08T18:57:11Z","updated_at":"2015-07-08T18:57:11Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677122"}],"start":"2015-09-14T00:00:00Z","finish":"2015-09-21T00:00:00Z"},{"kind":"iteration","number":14,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[],"start":"2015-09-21T00:00:00Z","finish":"2015-09-28T00:00:00Z"},{"kind":"iteration","number":15,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[],"start":"2015-09-28T00:00:00Z","finish":"2015-10-05T00:00:00Z"}]'
     http_version: 
-  recorded_at: Wed, 29 Jul 2015 14:47:37 GMT
+  recorded_at: Wed, 29 Jul 2015 14:47:34 GMT
 - request:
     method: get
     uri: https://www.pivotaltracker.com/services/v5/projects/<TRACKERPROJECT>/iterations?limit=10&offset=10&scope=current_backlog
@@ -184,11 +184,11 @@ http_interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 32dda8cb2d3a330f3a3810f88ab5ab87
+      - 12dfdff45f5d1afbb1a72322859b12a1
       X-Runtime:
-      - '0.039365'
+      - '0.042710'
       Date:
-      - Wed, 29 Jul 2015 14:47:38 GMT
+      - Wed, 29 Jul 2015 14:47:35 GMT
       X-Rack-Cache:
       - miss
       X-Powered-By:
@@ -225,7 +225,7 @@ http_interactions:
         up Engine Yard production environment","story_type":"chore","current_state":"unstarted","requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166932,"project_id":<TRACKERPROJECT>,"name":"deployment","created_at":"2015-07-08T18:57:11Z","updated_at":"2015-07-08T18:57:11Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677138"},{"kind":"story","id":98677140,"project_id":<TRACKERPROJECT>,"name":"Beta
         launch","story_type":"release","current_state":"unstarted","deadline":"2015-07-27T00:00:00Z","requested_by_id":379075,"owner_ids":[],"labels":[],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677140"}],"start":"2015-12-07T00:00:00Z","finish":"2015-12-14T00:00:00Z"}]'
     http_version: 
-  recorded_at: Wed, 29 Jul 2015 14:47:37 GMT
+  recorded_at: Wed, 29 Jul 2015 14:47:35 GMT
 - request:
     method: get
     uri: https://www.pivotaltracker.com/services/v5/projects/<TRACKERPROJECT>/iterations?limit=10&offset=20&scope=current_backlog
@@ -263,11 +263,11 @@ http_interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 7dd8dede43212c95a66a4546cd2fc469
+      - 363ec6117249d9952cb54114ec5669cd
       X-Runtime:
-      - '0.038112'
+      - '0.042036'
       Date:
-      - Wed, 29 Jul 2015 14:47:38 GMT
+      - Wed, 29 Jul 2015 14:47:35 GMT
       X-Rack-Cache:
       - miss
       X-Powered-By:
@@ -307,7 +307,7 @@ http_interactions:
         accounts","created_at":"2015-07-08T18:57:12Z","updated_at":"2015-07-08T18:57:12Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677156"},{"kind":"story","id":98677158,"project_id":<TRACKERPROJECT>,"name":"Provide
         feedback to designer about look/feel of site","story_type":"chore","current_state":"unstarted","requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166954,"project_id":<TRACKERPROJECT>,"name":"design","created_at":"2015-07-08T18:57:12Z","updated_at":"2015-07-08T18:57:12Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677158"}],"start":"2016-02-15T00:00:00Z","finish":"2016-02-22T00:00:00Z"}]'
     http_version: 
-  recorded_at: Wed, 29 Jul 2015 14:47:37 GMT
+  recorded_at: Wed, 29 Jul 2015 14:47:35 GMT
 - request:
     method: get
     uri: https://www.pivotaltracker.com/services/v5/projects/<TRACKERPROJECT>/iterations?limit=10&offset=30&scope=current_backlog
@@ -345,11 +345,11 @@ http_interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 6a1e64c938ecbfab64e176aa329cb7fa
+      - 913b7e4a8dbe9ee2f3375605a7469ce4
       X-Runtime:
-      - '0.046182'
+      - '0.041350'
       Date:
-      - Wed, 29 Jul 2015 14:47:38 GMT
+      - Wed, 29 Jul 2015 14:47:36 GMT
       X-Rack-Cache:
       - miss
       X-Powered-By:
@@ -393,7 +393,7 @@ http_interactions:
         higher number of production slices, for scaling","story_type":"chore","current_state":"unstarted","requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166932,"project_id":<TRACKERPROJECT>,"name":"deployment","created_at":"2015-07-08T18:57:11Z","updated_at":"2015-07-08T18:57:11Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:13Z","url":"https://www.pivotaltracker.com/story/show/98677186"},{"kind":"story","id":98677188,"project_id":<TRACKERPROJECT>,"name":"Full
         production launch","story_type":"release","current_state":"unstarted","requested_by_id":379075,"owner_ids":[],"labels":[],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:13Z","url":"https://www.pivotaltracker.com/story/show/98677188"}],"start":"2016-04-11T00:00:00Z","finish":"2016-04-18T00:00:00Z"}]'
     http_version: 
-  recorded_at: Wed, 29 Jul 2015 14:47:38 GMT
+  recorded_at: Wed, 29 Jul 2015 14:47:35 GMT
 - request:
     method: get
     uri: https://www.pivotaltracker.com/services/v5/projects/<TRACKERPROJECT>
@@ -423,11 +423,11 @@ http_interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 1d32aef3040af88b11541eb9e2bace80
+      - d7ada51c9fbf22c4ba7682b3f6100e94
       X-Runtime:
-      - '0.044229'
+      - '0.044594'
       Date:
-      - Wed, 29 Jul 2015 14:47:39 GMT
+      - Wed, 29 Jul 2015 14:47:36 GMT
       X-Rack-Cache:
       - miss
       X-Powered-By:
@@ -450,342 +450,55 @@ http_interactions:
         is a demo project, created by Tracker, with example stories for a simple shopping
         web site.","enable_incoming_emails":true,"initial_velocity":10,"public":false,"atom_enabled":false,"project_type":"demo","start_time":"2015-06-22T00:00:00Z","created_at":"2015-07-08T18:57:11Z","updated_at":"2015-07-08T19:01:19Z","account_id":774272,"current_iteration_number":6,"enable_following":true}'
     http_version: 
-  recorded_at: Wed, 29 Jul 2015 14:47:38 GMT
+  recorded_at: Wed, 29 Jul 2015 14:47:36 GMT
 - request:
-    method: get
-    uri: https://www.pivotaltracker.com/services/v5/projects/<TRACKERPROJECT>/iterations?scope=current_backlog
+    method: post
+    uri: https://www.pivotaltracker.com/services/v5/projects/<TRACKERPROJECT>/stories
     body:
-      encoding: US-ASCII
-      string: ''
+      encoding: UTF-8
+      string: '{"name":"As a customer, I want foo bar","description":"As an boss,
+        I want another drink, so that I get drunk","after_id":null}'
     headers:
       User-Agent:
       - Ruby/2.2.2 (x86_64-darwin14; ruby) TrackerApi/0.2.10 Faraday/0.9.1
       X-Trackertoken:
       - "<TRACKERAPITOKEN>"
+      Content-Type:
+      - application/json
   response:
     status:
-      code: 200
+      code: 400
       message: ''
     headers:
       Content-Type:
       - application/json; charset=utf-8
       Status:
-      - 200 OK
-      X-Tracker-Project-Version:
-      - '60'
-      X-Tracker-Pagination-Total:
-      - '38'
-      X-Tracker-Pagination-Offset:
-      - '0'
-      X-Tracker-Pagination-Limit:
-      - '10'
-      X-Tracker-Pagination-Returned:
-      - '10'
+      - 400 Bad Request
       X-Ua-Compatible:
       - IE=Edge,chrome=1
-      Etag:
-      - '"a45abde516f1b05b1d3db453cf2f1c66"'
       Cache-Control:
-      - max-age=0, private, must-revalidate
+      - no-cache
       X-Request-Id:
-      - bd1af1601a425a987b811a35a2b82b7b
+      - 03bde002fa0428fe910648a33905083f
       X-Runtime:
-      - '0.036562'
+      - '0.185369'
       Date:
-      - Wed, 29 Jul 2015 14:47:39 GMT
+      - Wed, 29 Jul 2015 14:47:37 GMT
       X-Rack-Cache:
-      - miss
+      - invalidate, pass
       X-Powered-By:
       - Phusion Passenger 4.0.41
       Server:
       - nginx/1.6.0 + Phusion Passenger 4.0.41
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Credentials:
-      - 'false'
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, DELETE, OPTIONS
-      Access-Control-Allow-Headers:
-      - X-TrackerToken,DNT,X-Mx-ReqToken,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,X-Tracker-Warn-Unless-Project-Version-Is
-      X-Tracker-Client-Pinger-Interval:
-      - '12'
     body:
       encoding: UTF-8
-      string: '[{"kind":"iteration","number":6,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[{"kind":"story","id":98677104,"project_id":<TRACKERPROJECT>,"name":"Shopper
-        should be able to view contents of shopping cart","description":"Cart icon
-        in top right corner, with a number indicating how many items in cart","story_type":"feature","current_state":"delivered","estimate":2,"requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166940,"project_id":<TRACKERPROJECT>,"name":"cart","created_at":"2015-07-08T18:57:11Z","updated_at":"2015-07-08T18:57:11Z"},{"kind":"label","id":12166936,"project_id":<TRACKERPROJECT>,"name":"shopping","created_at":"2015-07-08T18:57:11Z","updated_at":"2015-07-08T18:57:11Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:11Z","url":"https://www.pivotaltracker.com/story/show/98677104"},{"kind":"story","id":98677106,"project_id":<TRACKERPROJECT>,"name":"Shopper
-        should be able to remove product from shopping cart","story_type":"feature","current_state":"delivered","estimate":1,"requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166940,"project_id":<TRACKERPROJECT>,"name":"cart","created_at":"2015-07-08T18:57:11Z","updated_at":"2015-07-08T18:57:11Z"},{"kind":"label","id":12166936,"project_id":<TRACKERPROJECT>,"name":"shopping","created_at":"2015-07-08T18:57:11Z","updated_at":"2015-07-08T18:57:11Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:11Z","url":"https://www.pivotaltracker.com/story/show/98677106"},{"kind":"story","id":98677108,"project_id":<TRACKERPROJECT>,"name":"Cart
-        manipulation should be AJAXy","story_type":"feature","current_state":"finished","estimate":1,"requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166940,"project_id":<TRACKERPROJECT>,"name":"cart","created_at":"2015-07-08T18:57:11Z","updated_at":"2015-07-08T18:57:11Z"},{"kind":"label","id":12166936,"project_id":<TRACKERPROJECT>,"name":"shopping","created_at":"2015-07-08T18:57:11Z","updated_at":"2015-07-08T18:57:11Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677108"},{"kind":"story","id":98677110,"project_id":<TRACKERPROJECT>,"name":"Some
-        product photos not scaled properly when browsing products","story_type":"bug","current_state":"started","requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166936,"project_id":<TRACKERPROJECT>,"name":"shopping","created_at":"2015-07-08T18:57:11Z","updated_at":"2015-07-08T18:57:11Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677110"},{"kind":"story","id":98677112,"project_id":<TRACKERPROJECT>,"name":"Shopper
-        should be able to recommend a product to a friend","description":"Prompt for
-        email address and personalized message, send email with product details and
-        message","story_type":"feature","current_state":"started","estimate":1,"requested_by_id":379075,"owned_by_id":379075,"owner_ids":[379075],"labels":[{"kind":"label","id":12166936,"project_id":<TRACKERPROJECT>,"name":"shopping","created_at":"2015-07-08T18:57:11Z","updated_at":"2015-07-08T18:57:11Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-21T17:01:29Z","url":"https://www.pivotaltracker.com/story/show/98677112"}],"start":"2015-07-27T00:00:00Z","finish":"2015-08-03T00:00:00Z"},{"kind":"iteration","number":7,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[{"kind":"story","id":98988674,"project_id":<TRACKERPROJECT>,"name":"As
-        a customer, I want slack integration","description":"\nAs an customer, I want
-        slack integration, so that I can stop importing invoices manually.\n\n## Acceptance
-        Criteria\n\n* \n* \n","story_type":"feature","current_state":"unstarted","requested_by_id":379075,"owner_ids":[],"labels":[],"created_at":"2015-07-13T21:28:52Z","updated_at":"2015-07-22T23:10:14Z","url":"https://www.pivotaltracker.com/story/show/98988674"},{"kind":"story","id":99533038,"project_id":<TRACKERPROJECT>,"name":"Adding
-        a new story to the list","description":"This is a new story","story_type":"feature","current_state":"unstarted","requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12276718,"project_id":<TRACKERPROJECT>,"name":"with_label","created_at":"2015-07-21T16:59:37Z","updated_at":"2015-07-21T16:59:37Z"}],"created_at":"2015-07-21T16:59:37Z","updated_at":"2015-07-22T23:06:53Z","url":"https://www.pivotaltracker.com/story/show/99533038"},{"kind":"story","id":99432476,"project_id":<TRACKERPROJECT>,"name":"As
-        a RMS user, I want everything","description":"\nAs an RMS user, I want everything,
-        so that make money.\n\n## Acceptance Criteria\n\n* \n* \n","story_type":"feature","current_state":"unstarted","requested_by_id":379075,"owner_ids":[],"labels":[],"created_at":"2015-07-20T16:23:00Z","updated_at":"2015-07-20T20:08:54Z","url":"https://www.pivotaltracker.com/story/show/99432476"}],"start":"2015-08-03T00:00:00Z","finish":"2015-08-10T00:00:00Z"},{"kind":"iteration","number":8,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[],"start":"2015-08-10T00:00:00Z","finish":"2015-08-17T00:00:00Z"},{"kind":"iteration","number":9,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[{"kind":"story","id":99380320,"project_id":<TRACKERPROJECT>,"name":"As
-        a another customer, I want stuff","description":"\nAs an another customer,
-        I want stuff, so that its very important.\n\n## Acceptance Criteria\n\n* \n*
-        \n","story_type":"feature","current_state":"unstarted","estimate":3,"requested_by_id":379075,"owner_ids":[],"labels":[],"created_at":"2015-07-19T23:38:54Z","updated_at":"2015-07-21T17:02:02Z","url":"https://www.pivotaltracker.com/story/show/99380320"},{"kind":"story","id":98677114,"project_id":<TRACKERPROJECT>,"name":"configure
-        solr for full text searching","story_type":"chore","current_state":"unstarted","requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166942,"project_id":<TRACKERPROJECT>,"name":"search","created_at":"2015-07-08T18:57:12Z","updated_at":"2015-07-08T18:57:12Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677114"},{"kind":"story","id":98688698,"project_id":<TRACKERPROJECT>,"name":"trying
-        to insert after configure solr","story_type":"feature","current_state":"unstarted","requested_by_id":379075,"owner_ids":[],"labels":[],"created_at":"2015-07-08T21:01:30Z","updated_at":"2015-07-08T21:01:30Z","url":"https://www.pivotaltracker.com/story/show/98688698"},{"kind":"story","id":99852954,"project_id":<TRACKERPROJECT>,"name":"As
-        a customer, I want slack integration","description":"\nAs an customer, I want
-        slack integration, so that I can stop importing invoices manually.\n\n## Acceptance
-        Criteria\n\n* \n* \n","story_type":"feature","current_state":"unstarted","requested_by_id":379075,"owner_ids":[],"labels":[],"created_at":"2015-07-26T02:58:46Z","updated_at":"2015-07-26T02:58:46Z","url":"https://www.pivotaltracker.com/story/show/99852954"}],"start":"2015-08-17T00:00:00Z","finish":"2015-08-24T00:00:00Z"},{"kind":"iteration","number":10,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[],"start":"2015-08-24T00:00:00Z","finish":"2015-08-31T00:00:00Z"},{"kind":"iteration","number":11,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[],"start":"2015-08-31T00:00:00Z","finish":"2015-09-07T00:00:00Z"},{"kind":"iteration","number":12,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[{"kind":"story","id":98677116,"project_id":<TRACKERPROJECT>,"name":"Shopper
-        should be able to search for product","description":"One search field, search
-        should look through product name, description, and SKU","story_type":"feature","current_state":"unstarted","estimate":3,"requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166942,"project_id":<TRACKERPROJECT>,"name":"search","created_at":"2015-07-08T18:57:12Z","updated_at":"2015-07-08T18:57:12Z"},{"kind":"label","id":12166936,"project_id":<TRACKERPROJECT>,"name":"shopping","created_at":"2015-07-08T18:57:11Z","updated_at":"2015-07-08T18:57:11Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677116"},{"kind":"story","id":98677118,"project_id":<TRACKERPROJECT>,"name":"Initial
-        demo to investors","story_type":"release","current_state":"unstarted","requested_by_id":379075,"owner_ids":[],"labels":[],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677118"}],"start":"2015-09-07T00:00:00Z","finish":"2015-09-14T00:00:00Z"},{"kind":"iteration","number":13,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[{"kind":"story","id":98677120,"project_id":<TRACKERPROJECT>,"name":"Shopper
-        should be able to enter credit card information and shipping address","story_type":"feature","current_state":"unstarted","estimate":1,"requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166944,"project_id":<TRACKERPROJECT>,"name":"checkout","created_at":"2015-07-08T18:57:12Z","updated_at":"2015-07-08T18:57:12Z"},{"kind":"label","id":12166936,"project_id":<TRACKERPROJECT>,"name":"shopping","created_at":"2015-07-08T18:57:11Z","updated_at":"2015-07-08T18:57:11Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677120"},{"kind":"story","id":98677122,"project_id":<TRACKERPROJECT>,"name":"Integrate
-        with payment gateway","story_type":"chore","current_state":"unstarted","requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166944,"project_id":<TRACKERPROJECT>,"name":"checkout","created_at":"2015-07-08T18:57:12Z","updated_at":"2015-07-08T18:57:12Z"},{"kind":"label","id":12166936,"project_id":<TRACKERPROJECT>,"name":"shopping","created_at":"2015-07-08T18:57:11Z","updated_at":"2015-07-08T18:57:11Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677122"}],"start":"2015-09-14T00:00:00Z","finish":"2015-09-21T00:00:00Z"},{"kind":"iteration","number":14,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[],"start":"2015-09-21T00:00:00Z","finish":"2015-09-28T00:00:00Z"},{"kind":"iteration","number":15,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[],"start":"2015-09-28T00:00:00Z","finish":"2015-10-05T00:00:00Z"}]'
+      string: '{"code":"invalid_parameter","kind":"error","error":"One or more request
+        parameters was missing or invalid.","requirement":"Command parameters that
+        directly set properties of resources must be identical to the result value.","general_problem":"Got
+        bad values for the following parameter(s):  none of the supplied object-move
+        parameters match the generated results (''after_id'' parameter was  but result
+        was 98677188)","possible_fix":"Normalize the parameter values before sending
+        them to the server."}'
     http_version: 
-  recorded_at: Wed, 29 Jul 2015 14:47:38 GMT
-- request:
-    method: get
-    uri: https://www.pivotaltracker.com/services/v5/projects/<TRACKERPROJECT>/iterations?limit=10&offset=10&scope=current_backlog
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - Ruby/2.2.2 (x86_64-darwin14; ruby) TrackerApi/0.2.10 Faraday/0.9.1
-      X-Trackertoken:
-      - "<TRACKERAPITOKEN>"
-  response:
-    status:
-      code: 200
-      message: ''
-    headers:
-      Content-Type:
-      - application/json; charset=utf-8
-      Status:
-      - 200 OK
-      X-Tracker-Project-Version:
-      - '60'
-      X-Tracker-Pagination-Total:
-      - '38'
-      X-Tracker-Pagination-Offset:
-      - '10'
-      X-Tracker-Pagination-Limit:
-      - '10'
-      X-Tracker-Pagination-Returned:
-      - '10'
-      X-Ua-Compatible:
-      - IE=Edge,chrome=1
-      Etag:
-      - '"605d5ce640c91e3bf2a19a2d44f31c02"'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      X-Request-Id:
-      - f7e09238d98fffcf023d74d8d8f69691
-      X-Runtime:
-      - '0.037959'
-      Date:
-      - Wed, 29 Jul 2015 14:47:39 GMT
-      X-Rack-Cache:
-      - miss
-      X-Powered-By:
-      - Phusion Passenger 4.0.41
-      Server:
-      - nginx/1.6.0 + Phusion Passenger 4.0.41
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Credentials:
-      - 'false'
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, DELETE, OPTIONS
-      Access-Control-Allow-Headers:
-      - X-TrackerToken,DNT,X-Mx-ReqToken,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,X-Tracker-Warn-Unless-Project-Version-Is
-      X-Tracker-Client-Pinger-Interval:
-      - '12'
-    body:
-      encoding: UTF-8
-      string: '[{"kind":"iteration","number":16,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[{"kind":"story","id":98677124,"project_id":<TRACKERPROJECT>,"name":"When
-        shopper submits order, authorize total product amount from payment gateway","story_type":"feature","current_state":"unstarted","estimate":3,"requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166944,"project_id":<TRACKERPROJECT>,"name":"checkout","created_at":"2015-07-08T18:57:12Z","updated_at":"2015-07-08T18:57:12Z"},{"kind":"label","id":12166946,"project_id":<TRACKERPROJECT>,"name":"needs
-        discussion","created_at":"2015-07-08T18:57:12Z","updated_at":"2015-07-08T18:57:12Z"},{"kind":"label","id":12166936,"project_id":<TRACKERPROJECT>,"name":"shopping","created_at":"2015-07-08T18:57:11Z","updated_at":"2015-07-08T18:57:11Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677124"}],"start":"2015-10-05T00:00:00Z","finish":"2015-10-12T00:00:00Z"},{"kind":"iteration","number":17,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[{"kind":"story","id":98677126,"project_id":<TRACKERPROJECT>,"name":"If
-        system fails to authorize payment amount, display error message to shopper","story_type":"feature","current_state":"unstarted","estimate":1,"requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166944,"project_id":<TRACKERPROJECT>,"name":"checkout","created_at":"2015-07-08T18:57:12Z","updated_at":"2015-07-08T18:57:12Z"},{"kind":"label","id":12166936,"project_id":<TRACKERPROJECT>,"name":"shopping","created_at":"2015-07-08T18:57:11Z","updated_at":"2015-07-08T18:57:11Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677126"}],"start":"2015-10-12T00:00:00Z","finish":"2015-10-19T00:00:00Z"},{"kind":"iteration","number":18,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[{"kind":"story","id":98677128,"project_id":<TRACKERPROJECT>,"name":"If
-        authorization is successful, show order number and confirmation message to
-        shopper","story_type":"feature","current_state":"unstarted","estimate":1,"requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166944,"project_id":<TRACKERPROJECT>,"name":"checkout","created_at":"2015-07-08T18:57:12Z","updated_at":"2015-07-08T18:57:12Z"},{"kind":"label","id":12166936,"project_id":<TRACKERPROJECT>,"name":"shopping","created_at":"2015-07-08T18:57:11Z","updated_at":"2015-07-08T18:57:11Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677128"},{"kind":"story","id":98688754,"project_id":<TRACKERPROJECT>,"name":"Foo
-        Bar 2","story_type":"feature","current_state":"unstarted","requested_by_id":379075,"owner_ids":[],"labels":[],"created_at":"2015-07-08T21:02:19Z","updated_at":"2015-07-08T21:02:19Z","url":"https://www.pivotaltracker.com/story/show/98688754"}],"start":"2015-10-19T00:00:00Z","finish":"2015-10-26T00:00:00Z"},{"kind":"iteration","number":19,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[],"start":"2015-10-26T00:00:00Z","finish":"2015-11-02T00:00:00Z"},{"kind":"iteration","number":20,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[{"kind":"story","id":99260190,"project_id":<TRACKERPROJECT>,"name":"As
-        a fdoo, I want bar","description":"\nAs an fdoo, I want bar, so that baz.\n\n##
-        Acceptance Criteria\n\n* \n* \n","story_type":"feature","current_state":"unstarted","estimate":2,"requested_by_id":379075,"owner_ids":[],"labels":[],"created_at":"2015-07-16T20:49:18Z","updated_at":"2015-07-16T21:00:42Z","url":"https://www.pivotaltracker.com/story/show/99260190"}],"start":"2015-11-02T00:00:00Z","finish":"2015-11-09T00:00:00Z"},{"kind":"iteration","number":21,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[{"kind":"story","id":98677130,"project_id":<TRACKERPROJECT>,"name":"Send
-        notification email of order placement to admin","story_type":"feature","current_state":"unstarted","estimate":1,"requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166934,"project_id":<TRACKERPROJECT>,"name":"admin","created_at":"2015-07-08T18:57:11Z","updated_at":"2015-07-08T18:57:11Z"},{"kind":"label","id":12166944,"project_id":<TRACKERPROJECT>,"name":"checkout","created_at":"2015-07-08T18:57:12Z","updated_at":"2015-07-08T18:57:12Z"},{"kind":"label","id":12166936,"project_id":<TRACKERPROJECT>,"name":"shopping","created_at":"2015-07-08T18:57:11Z","updated_at":"2015-07-08T18:57:11Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677130"}],"start":"2015-11-09T00:00:00Z","finish":"2015-11-16T00:00:00Z"},{"kind":"iteration","number":22,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[],"start":"2015-11-16T00:00:00Z","finish":"2015-11-23T00:00:00Z"},{"kind":"iteration","number":23,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[{"kind":"story","id":98677132,"project_id":<TRACKERPROJECT>,"name":"Shopper
-        should be able to check status of order by entering name and order number","story_type":"feature","current_state":"unstarted","estimate":2,"requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166948,"project_id":<TRACKERPROJECT>,"name":"orders","created_at":"2015-07-08T18:57:12Z","updated_at":"2015-07-08T18:57:12Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677132"}],"start":"2015-11-23T00:00:00Z","finish":"2015-11-30T00:00:00Z"},{"kind":"iteration","number":24,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[{"kind":"story","id":98677134,"project_id":<TRACKERPROJECT>,"name":"Shopper
-        should be able to ask question about order","description":"When checking status
-        of order, shopper should have the option to ask a question. This should send
-        email to admin.","story_type":"feature","current_state":"unstarted","estimate":1,"requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166948,"project_id":<TRACKERPROJECT>,"name":"orders","created_at":"2015-07-08T18:57:12Z","updated_at":"2015-07-08T18:57:12Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677134"}],"start":"2015-11-30T00:00:00Z","finish":"2015-12-07T00:00:00Z"},{"kind":"iteration","number":25,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[{"kind":"story","id":98677136,"project_id":<TRACKERPROJECT>,"name":"Admin
-        can review all order questions and send responses to shoppers","story_type":"feature","current_state":"unstarted","estimate":1,"requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166934,"project_id":<TRACKERPROJECT>,"name":"admin","created_at":"2015-07-08T18:57:11Z","updated_at":"2015-07-08T18:57:11Z"},{"kind":"label","id":12166948,"project_id":<TRACKERPROJECT>,"name":"orders","created_at":"2015-07-08T18:57:12Z","updated_at":"2015-07-08T18:57:12Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677136"},{"kind":"story","id":98677138,"project_id":<TRACKERPROJECT>,"name":"Set
-        up Engine Yard production environment","story_type":"chore","current_state":"unstarted","requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166932,"project_id":<TRACKERPROJECT>,"name":"deployment","created_at":"2015-07-08T18:57:11Z","updated_at":"2015-07-08T18:57:11Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677138"},{"kind":"story","id":98677140,"project_id":<TRACKERPROJECT>,"name":"Beta
-        launch","story_type":"release","current_state":"unstarted","deadline":"2015-07-27T00:00:00Z","requested_by_id":379075,"owner_ids":[],"labels":[],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677140"}],"start":"2015-12-07T00:00:00Z","finish":"2015-12-14T00:00:00Z"}]'
-    http_version: 
-  recorded_at: Wed, 29 Jul 2015 14:47:39 GMT
-- request:
-    method: get
-    uri: https://www.pivotaltracker.com/services/v5/projects/<TRACKERPROJECT>/iterations?limit=10&offset=20&scope=current_backlog
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - Ruby/2.2.2 (x86_64-darwin14; ruby) TrackerApi/0.2.10 Faraday/0.9.1
-      X-Trackertoken:
-      - "<TRACKERAPITOKEN>"
-  response:
-    status:
-      code: 200
-      message: ''
-    headers:
-      Content-Type:
-      - application/json; charset=utf-8
-      Status:
-      - 200 OK
-      X-Tracker-Project-Version:
-      - '60'
-      X-Tracker-Pagination-Total:
-      - '38'
-      X-Tracker-Pagination-Offset:
-      - '20'
-      X-Tracker-Pagination-Limit:
-      - '10'
-      X-Tracker-Pagination-Returned:
-      - '10'
-      X-Ua-Compatible:
-      - IE=Edge,chrome=1
-      Etag:
-      - '"6d672d053b6acbac48e7708ae2286b55"'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      X-Request-Id:
-      - 501d693ac9a04b7d8fc98ea3a27222ca
-      X-Runtime:
-      - '0.038911'
-      Date:
-      - Wed, 29 Jul 2015 14:47:40 GMT
-      X-Rack-Cache:
-      - miss
-      X-Powered-By:
-      - Phusion Passenger 4.0.41
-      Server:
-      - nginx/1.6.0 + Phusion Passenger 4.0.41
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Credentials:
-      - 'false'
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, DELETE, OPTIONS
-      Access-Control-Allow-Headers:
-      - X-TrackerToken,DNT,X-Mx-ReqToken,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,X-Tracker-Warn-Unless-Project-Version-Is
-      X-Tracker-Client-Pinger-Interval:
-      - '12'
-    body:
-      encoding: UTF-8
-      string: '[{"kind":"iteration","number":26,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[],"start":"2015-12-14T00:00:00Z","finish":"2015-12-21T00:00:00Z"},{"kind":"iteration","number":27,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[{"kind":"story","id":98677142,"project_id":<TRACKERPROJECT>,"name":"Shopper
-        should be able to sign up for an account with email address","story_type":"feature","current_state":"unstarted","estimate":2,"requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166950,"project_id":<TRACKERPROJECT>,"name":"signup
-        / signin","created_at":"2015-07-08T18:57:12Z","updated_at":"2015-07-08T18:57:12Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677142"}],"start":"2015-12-21T00:00:00Z","finish":"2015-12-28T00:00:00Z"},{"kind":"iteration","number":28,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[{"kind":"story","id":98677144,"project_id":<TRACKERPROJECT>,"name":"Shopper
-        should be able to reset forgotten password","story_type":"feature","current_state":"unstarted","estimate":1,"requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166950,"project_id":<TRACKERPROJECT>,"name":"signup
-        / signin","created_at":"2015-07-08T18:57:12Z","updated_at":"2015-07-08T18:57:12Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677144"}],"start":"2015-12-28T00:00:00Z","finish":"2016-01-04T00:00:00Z"},{"kind":"iteration","number":29,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[{"kind":"story","id":98677146,"project_id":<TRACKERPROJECT>,"name":"Shopper
-        should be able to log out","story_type":"feature","current_state":"unstarted","estimate":1,"requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166950,"project_id":<TRACKERPROJECT>,"name":"signup
-        / signin","created_at":"2015-07-08T18:57:12Z","updated_at":"2015-07-08T18:57:12Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677146"}],"start":"2016-01-04T00:00:00Z","finish":"2016-01-11T00:00:00Z"},{"kind":"iteration","number":30,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[{"kind":"story","id":98677148,"project_id":<TRACKERPROJECT>,"name":"When
-        checking out, shopper should have the option to sign in to their account","story_type":"feature","current_state":"unstarted","estimate":1,"requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166950,"project_id":<TRACKERPROJECT>,"name":"signup
-        / signin","created_at":"2015-07-08T18:57:12Z","updated_at":"2015-07-08T18:57:12Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677148"}],"start":"2016-01-11T00:00:00Z","finish":"2016-01-18T00:00:00Z"},{"kind":"iteration","number":31,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[{"kind":"story","id":98677150,"project_id":<TRACKERPROJECT>,"name":"Signed
-        in shopper should be able to review order history","description":"Show orders
-        in last 60 days, with link to show older orders","story_type":"feature","current_state":"unstarted","estimate":1,"requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166952,"project_id":<TRACKERPROJECT>,"name":"shopper
-        accounts","created_at":"2015-07-08T18:57:12Z","updated_at":"2015-07-08T18:57:12Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677150"}],"start":"2016-01-18T00:00:00Z","finish":"2016-01-25T00:00:00Z"},{"kind":"iteration","number":32,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[],"start":"2016-01-25T00:00:00Z","finish":"2016-02-01T00:00:00Z"},{"kind":"iteration","number":33,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[{"kind":"story","id":98677152,"project_id":<TRACKERPROJECT>,"name":"Signed
-        in shopper should be able to save credit card and address information used
-        in checkout","description":"Credit card numbers should be stored encrypted","story_type":"feature","current_state":"unstarted","estimate":2,"requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166952,"project_id":<TRACKERPROJECT>,"name":"shopper
-        accounts","created_at":"2015-07-08T18:57:12Z","updated_at":"2015-07-08T18:57:12Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677152"}],"start":"2016-02-01T00:00:00Z","finish":"2016-02-08T00:00:00Z"},{"kind":"iteration","number":34,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[{"kind":"story","id":98677154,"project_id":<TRACKERPROJECT>,"name":"Signed
-        in shopper should be able to save product to favorites","story_type":"feature","current_state":"unstarted","estimate":1,"requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166952,"project_id":<TRACKERPROJECT>,"name":"shopper
-        accounts","created_at":"2015-07-08T18:57:12Z","updated_at":"2015-07-08T18:57:12Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677154"}],"start":"2016-02-08T00:00:00Z","finish":"2016-02-15T00:00:00Z"},{"kind":"iteration","number":35,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[{"kind":"story","id":98677156,"project_id":<TRACKERPROJECT>,"name":"Signed
-        in shopper should be able to review and remove product from favorites","story_type":"feature","current_state":"unstarted","estimate":1,"requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166952,"project_id":<TRACKERPROJECT>,"name":"shopper
-        accounts","created_at":"2015-07-08T18:57:12Z","updated_at":"2015-07-08T18:57:12Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677156"},{"kind":"story","id":98677158,"project_id":<TRACKERPROJECT>,"name":"Provide
-        feedback to designer about look/feel of site","story_type":"chore","current_state":"unstarted","requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166954,"project_id":<TRACKERPROJECT>,"name":"design","created_at":"2015-07-08T18:57:12Z","updated_at":"2015-07-08T18:57:12Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677158"}],"start":"2016-02-15T00:00:00Z","finish":"2016-02-22T00:00:00Z"}]'
-    http_version: 
-  recorded_at: Wed, 29 Jul 2015 14:47:39 GMT
-- request:
-    method: get
-    uri: https://www.pivotaltracker.com/services/v5/projects/<TRACKERPROJECT>/iterations?limit=10&offset=30&scope=current_backlog
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - Ruby/2.2.2 (x86_64-darwin14; ruby) TrackerApi/0.2.10 Faraday/0.9.1
-      X-Trackertoken:
-      - "<TRACKERAPITOKEN>"
-  response:
-    status:
-      code: 200
-      message: ''
-    headers:
-      Content-Type:
-      - application/json; charset=utf-8
-      Status:
-      - 200 OK
-      X-Tracker-Project-Version:
-      - '60'
-      X-Tracker-Pagination-Total:
-      - '38'
-      X-Tracker-Pagination-Offset:
-      - '30'
-      X-Tracker-Pagination-Limit:
-      - '10'
-      X-Tracker-Pagination-Returned:
-      - '8'
-      X-Ua-Compatible:
-      - IE=Edge,chrome=1
-      Etag:
-      - '"33834fa7c8aa742f6387c9d3c31fd6c5"'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      X-Request-Id:
-      - 6eae5d9de292e214b9ab69e213d8d8f9
-      X-Runtime:
-      - '0.042543'
-      Date:
-      - Wed, 29 Jul 2015 14:47:40 GMT
-      X-Rack-Cache:
-      - miss
-      X-Powered-By:
-      - Phusion Passenger 4.0.41
-      Server:
-      - nginx/1.6.0 + Phusion Passenger 4.0.41
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Credentials:
-      - 'false'
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, DELETE, OPTIONS
-      Access-Control-Allow-Headers:
-      - X-TrackerToken,DNT,X-Mx-ReqToken,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,X-Tracker-Warn-Unless-Project-Version-Is
-      X-Tracker-Client-Pinger-Interval:
-      - '12'
-    body:
-      encoding: UTF-8
-      string: '[{"kind":"iteration","number":36,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[],"start":"2016-02-22T00:00:00Z","finish":"2016-02-29T00:00:00Z"},{"kind":"iteration","number":37,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[],"start":"2016-02-29T00:00:00Z","finish":"2016-03-07T00:00:00Z"},{"kind":"iteration","number":38,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[{"kind":"story","id":98677160,"project_id":<TRACKERPROJECT>,"name":"Apply
-        styling to all shopper facing parts of the site, based on assets from designer","story_type":"feature","current_state":"unstarted","estimate":3,"requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166954,"project_id":<TRACKERPROJECT>,"name":"design","created_at":"2015-07-08T18:57:12Z","updated_at":"2015-07-08T18:57:12Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677160"}],"start":"2016-03-07T00:00:00Z","finish":"2016-03-14T00:00:00Z"},{"kind":"iteration","number":39,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[],"start":"2016-03-14T00:00:00Z","finish":"2016-03-21T00:00:00Z"},{"kind":"iteration","number":40,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[{"kind":"story","id":98677162,"project_id":<TRACKERPROJECT>,"name":"Signed
-        in shopper should be able to post product reviews","story_type":"feature","current_state":"unstarted","estimate":2,"requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166956,"project_id":<TRACKERPROJECT>,"name":"user
-        generated content","created_at":"2015-07-08T18:57:12Z","updated_at":"2015-07-08T18:57:12Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677162"}],"start":"2016-03-21T00:00:00Z","finish":"2016-03-28T00:00:00Z"},{"kind":"iteration","number":41,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[{"kind":"story","id":98677164,"project_id":<TRACKERPROJECT>,"name":"Signed
-        in shopper should be able to rate product, by choosing 1-5 stars","story_type":"feature","current_state":"unstarted","estimate":1,"requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166956,"project_id":<TRACKERPROJECT>,"name":"user
-        generated content","created_at":"2015-07-08T18:57:12Z","updated_at":"2015-07-08T18:57:12Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677164"}],"start":"2016-03-28T00:00:00Z","finish":"2016-04-04T00:00:00Z"},{"kind":"iteration","number":42,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[{"kind":"story","id":98677166,"project_id":<TRACKERPROJECT>,"name":"When
-        shopper is browsing products, show average product rating and number of reviews
-        next to each product","story_type":"feature","current_state":"unstarted","estimate":1,"requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166956,"project_id":<TRACKERPROJECT>,"name":"user
-        generated content","created_at":"2015-07-08T18:57:12Z","updated_at":"2015-07-08T18:57:12Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:13Z","url":"https://www.pivotaltracker.com/story/show/98677166"}],"start":"2016-04-04T00:00:00Z","finish":"2016-04-11T00:00:00Z"},{"kind":"iteration","number":43,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[{"kind":"story","id":98677168,"project_id":<TRACKERPROJECT>,"name":"Shopper
-        should be able to read reviews for a product","story_type":"feature","current_state":"unstarted","estimate":1,"requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166956,"project_id":<TRACKERPROJECT>,"name":"user
-        generated content","created_at":"2015-07-08T18:57:12Z","updated_at":"2015-07-08T18:57:12Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:13Z","url":"https://www.pivotaltracker.com/story/show/98677168"},{"kind":"story","id":98677170,"project_id":<TRACKERPROJECT>,"name":"Admin
-        should be able to mark a product as featured","story_type":"feature","current_state":"unstarted","requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166934,"project_id":<TRACKERPROJECT>,"name":"admin","created_at":"2015-07-08T18:57:11Z","updated_at":"2015-07-08T18:57:11Z"},{"kind":"label","id":12166958,"project_id":<TRACKERPROJECT>,"name":"featured
-        products","created_at":"2015-07-08T18:57:13Z","updated_at":"2015-07-08T18:57:13Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:13Z","url":"https://www.pivotaltracker.com/story/show/98677170"},{"kind":"story","id":98677172,"project_id":<TRACKERPROJECT>,"name":"Featured
-        products should appear on the site landing page","story_type":"feature","current_state":"unstarted","requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166958,"project_id":<TRACKERPROJECT>,"name":"featured
-        products","created_at":"2015-07-08T18:57:13Z","updated_at":"2015-07-08T18:57:13Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:13Z","url":"https://www.pivotaltracker.com/story/show/98677172"},{"kind":"story","id":98677174,"project_id":<TRACKERPROJECT>,"name":"Admin
-        should be able to create and edit blog articles","story_type":"feature","current_state":"unstarted","requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166934,"project_id":<TRACKERPROJECT>,"name":"admin","created_at":"2015-07-08T18:57:11Z","updated_at":"2015-07-08T18:57:11Z"},{"kind":"label","id":12166960,"project_id":<TRACKERPROJECT>,"name":"blog","created_at":"2015-07-08T18:57:13Z","updated_at":"2015-07-08T18:57:13Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:13Z","url":"https://www.pivotaltracker.com/story/show/98677174"},{"kind":"story","id":98677176,"project_id":<TRACKERPROJECT>,"name":"Admin
-        should be able to save blog articles in draft mode","story_type":"feature","current_state":"unstarted","requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166934,"project_id":<TRACKERPROJECT>,"name":"admin","created_at":"2015-07-08T18:57:11Z","updated_at":"2015-07-08T18:57:11Z"},{"kind":"label","id":12166960,"project_id":<TRACKERPROJECT>,"name":"blog","created_at":"2015-07-08T18:57:13Z","updated_at":"2015-07-08T18:57:13Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:13Z","url":"https://www.pivotaltracker.com/story/show/98677176"},{"kind":"story","id":98677178,"project_id":<TRACKERPROJECT>,"name":"Published
-        blog articles should appear on the site","story_type":"feature","current_state":"unstarted","requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166960,"project_id":<TRACKERPROJECT>,"name":"blog","created_at":"2015-07-08T18:57:13Z","updated_at":"2015-07-08T18:57:13Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:13Z","url":"https://www.pivotaltracker.com/story/show/98677178"},{"kind":"story","id":98677180,"project_id":<TRACKERPROJECT>,"name":"People
-        should be able to subscribe to blog via RSS and Atom","story_type":"feature","current_state":"unstarted","requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166960,"project_id":<TRACKERPROJECT>,"name":"blog","created_at":"2015-07-08T18:57:13Z","updated_at":"2015-07-08T18:57:13Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:13Z","url":"https://www.pivotaltracker.com/story/show/98677180"},{"kind":"story","id":98677182,"project_id":<TRACKERPROJECT>,"name":"Admin
-        should be able to view monthly sales report","story_type":"feature","current_state":"unstarted","requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166934,"project_id":<TRACKERPROJECT>,"name":"admin","created_at":"2015-07-08T18:57:11Z","updated_at":"2015-07-08T18:57:11Z"},{"kind":"label","id":12166962,"project_id":<TRACKERPROJECT>,"name":"reporting","created_at":"2015-07-08T18:57:13Z","updated_at":"2015-07-08T18:57:13Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:13Z","url":"https://www.pivotaltracker.com/story/show/98677182"},{"kind":"story","id":98677184,"project_id":<TRACKERPROJECT>,"name":"Admin
-        should be able to export orders as CSV file, based on date range and order
-        status","story_type":"feature","current_state":"unstarted","requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166934,"project_id":<TRACKERPROJECT>,"name":"admin","created_at":"2015-07-08T18:57:11Z","updated_at":"2015-07-08T18:57:11Z"},{"kind":"label","id":12166962,"project_id":<TRACKERPROJECT>,"name":"reporting","created_at":"2015-07-08T18:57:13Z","updated_at":"2015-07-08T18:57:13Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:13Z","url":"https://www.pivotaltracker.com/story/show/98677184"},{"kind":"story","id":98677186,"project_id":<TRACKERPROJECT>,"name":"Request
-        higher number of production slices, for scaling","story_type":"chore","current_state":"unstarted","requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166932,"project_id":<TRACKERPROJECT>,"name":"deployment","created_at":"2015-07-08T18:57:11Z","updated_at":"2015-07-08T18:57:11Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:13Z","url":"https://www.pivotaltracker.com/story/show/98677186"},{"kind":"story","id":98677188,"project_id":<TRACKERPROJECT>,"name":"Full
-        production launch","story_type":"release","current_state":"unstarted","requested_by_id":379075,"owner_ids":[],"labels":[],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:13Z","url":"https://www.pivotaltracker.com/story/show/98677188"}],"start":"2016-04-11T00:00:00Z","finish":"2016-04-18T00:00:00Z"}]'
-    http_version: 
-  recorded_at: Wed, 29 Jul 2015 14:47:39 GMT
+  recorded_at: Wed, 29 Jul 2015 14:47:36 GMT
 recorded_with: VCR 2.9.3

--- a/spec/cassettes/Story_review_process/as_an_admin/has_the_ability_to_approve_and_reject.yml
+++ b/spec/cassettes/Story_review_process/as_an_admin/has_the_ability_to_approve_and_reject.yml
@@ -29,11 +29,11 @@ http_interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 5ccce4de2d2fe5465b3234f6fdd7019f
+      - 0f27e13f9d21717fe40512f56f360cd7
       X-Runtime:
-      - '0.041147'
+      - '0.046743'
       Date:
-      - Wed, 29 Jul 2015 14:47:37 GMT
+      - Wed, 29 Jul 2015 14:48:49 GMT
       X-Rack-Cache:
       - miss
       X-Powered-By:
@@ -56,7 +56,7 @@ http_interactions:
         is a demo project, created by Tracker, with example stories for a simple shopping
         web site.","enable_incoming_emails":true,"initial_velocity":10,"public":false,"atom_enabled":false,"project_type":"demo","start_time":"2015-06-22T00:00:00Z","created_at":"2015-07-08T18:57:11Z","updated_at":"2015-07-08T19:01:19Z","account_id":774272,"current_iteration_number":6,"enable_following":true}'
     http_version: 
-  recorded_at: Wed, 29 Jul 2015 14:47:37 GMT
+  recorded_at: Wed, 29 Jul 2015 14:48:48 GMT
 - request:
     method: get
     uri: https://www.pivotaltracker.com/services/v5/projects/<TRACKERPROJECT>/iterations?scope=current_backlog
@@ -94,11 +94,11 @@ http_interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 3247bc71a1f74e9bed17d93ca2d6078b
+      - f5b3bba5bf9924e6a50b0fcda316e33a
       X-Runtime:
-      - '0.041152'
+      - '0.037973'
       Date:
-      - Wed, 29 Jul 2015 14:47:37 GMT
+      - Wed, 29 Jul 2015 14:48:49 GMT
       X-Rack-Cache:
       - miss
       X-Powered-By:
@@ -146,7 +146,7 @@ http_interactions:
         should be able to enter credit card information and shipping address","story_type":"feature","current_state":"unstarted","estimate":1,"requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166944,"project_id":<TRACKERPROJECT>,"name":"checkout","created_at":"2015-07-08T18:57:12Z","updated_at":"2015-07-08T18:57:12Z"},{"kind":"label","id":12166936,"project_id":<TRACKERPROJECT>,"name":"shopping","created_at":"2015-07-08T18:57:11Z","updated_at":"2015-07-08T18:57:11Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677120"},{"kind":"story","id":98677122,"project_id":<TRACKERPROJECT>,"name":"Integrate
         with payment gateway","story_type":"chore","current_state":"unstarted","requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166944,"project_id":<TRACKERPROJECT>,"name":"checkout","created_at":"2015-07-08T18:57:12Z","updated_at":"2015-07-08T18:57:12Z"},{"kind":"label","id":12166936,"project_id":<TRACKERPROJECT>,"name":"shopping","created_at":"2015-07-08T18:57:11Z","updated_at":"2015-07-08T18:57:11Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677122"}],"start":"2015-09-14T00:00:00Z","finish":"2015-09-21T00:00:00Z"},{"kind":"iteration","number":14,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[],"start":"2015-09-21T00:00:00Z","finish":"2015-09-28T00:00:00Z"},{"kind":"iteration","number":15,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[],"start":"2015-09-28T00:00:00Z","finish":"2015-10-05T00:00:00Z"}]'
     http_version: 
-  recorded_at: Wed, 29 Jul 2015 14:47:37 GMT
+  recorded_at: Wed, 29 Jul 2015 14:48:48 GMT
 - request:
     method: get
     uri: https://www.pivotaltracker.com/services/v5/projects/<TRACKERPROJECT>/iterations?limit=10&offset=10&scope=current_backlog
@@ -184,11 +184,11 @@ http_interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 32dda8cb2d3a330f3a3810f88ab5ab87
+      - 0ccb342cfbf8fea845da971c6cadf441
       X-Runtime:
-      - '0.039365'
+      - '0.046766'
       Date:
-      - Wed, 29 Jul 2015 14:47:38 GMT
+      - Wed, 29 Jul 2015 14:48:49 GMT
       X-Rack-Cache:
       - miss
       X-Powered-By:
@@ -225,7 +225,7 @@ http_interactions:
         up Engine Yard production environment","story_type":"chore","current_state":"unstarted","requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166932,"project_id":<TRACKERPROJECT>,"name":"deployment","created_at":"2015-07-08T18:57:11Z","updated_at":"2015-07-08T18:57:11Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677138"},{"kind":"story","id":98677140,"project_id":<TRACKERPROJECT>,"name":"Beta
         launch","story_type":"release","current_state":"unstarted","deadline":"2015-07-27T00:00:00Z","requested_by_id":379075,"owner_ids":[],"labels":[],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677140"}],"start":"2015-12-07T00:00:00Z","finish":"2015-12-14T00:00:00Z"}]'
     http_version: 
-  recorded_at: Wed, 29 Jul 2015 14:47:37 GMT
+  recorded_at: Wed, 29 Jul 2015 14:48:49 GMT
 - request:
     method: get
     uri: https://www.pivotaltracker.com/services/v5/projects/<TRACKERPROJECT>/iterations?limit=10&offset=20&scope=current_backlog
@@ -263,11 +263,11 @@ http_interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 7dd8dede43212c95a66a4546cd2fc469
+      - 23d815ca027e84c5c1a78739be239f11
       X-Runtime:
-      - '0.038112'
+      - '0.038756'
       Date:
-      - Wed, 29 Jul 2015 14:47:38 GMT
+      - Wed, 29 Jul 2015 14:48:49 GMT
       X-Rack-Cache:
       - miss
       X-Powered-By:
@@ -307,7 +307,7 @@ http_interactions:
         accounts","created_at":"2015-07-08T18:57:12Z","updated_at":"2015-07-08T18:57:12Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677156"},{"kind":"story","id":98677158,"project_id":<TRACKERPROJECT>,"name":"Provide
         feedback to designer about look/feel of site","story_type":"chore","current_state":"unstarted","requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166954,"project_id":<TRACKERPROJECT>,"name":"design","created_at":"2015-07-08T18:57:12Z","updated_at":"2015-07-08T18:57:12Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677158"}],"start":"2016-02-15T00:00:00Z","finish":"2016-02-22T00:00:00Z"}]'
     http_version: 
-  recorded_at: Wed, 29 Jul 2015 14:47:37 GMT
+  recorded_at: Wed, 29 Jul 2015 14:48:49 GMT
 - request:
     method: get
     uri: https://www.pivotaltracker.com/services/v5/projects/<TRACKERPROJECT>/iterations?limit=10&offset=30&scope=current_backlog
@@ -345,11 +345,11 @@ http_interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 6a1e64c938ecbfab64e176aa329cb7fa
+      - effa2be52073707aa661ff7dfbf3f15c
       X-Runtime:
-      - '0.046182'
+      - '0.052872'
       Date:
-      - Wed, 29 Jul 2015 14:47:38 GMT
+      - Wed, 29 Jul 2015 14:48:50 GMT
       X-Rack-Cache:
       - miss
       X-Powered-By:
@@ -393,7 +393,7 @@ http_interactions:
         higher number of production slices, for scaling","story_type":"chore","current_state":"unstarted","requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166932,"project_id":<TRACKERPROJECT>,"name":"deployment","created_at":"2015-07-08T18:57:11Z","updated_at":"2015-07-08T18:57:11Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:13Z","url":"https://www.pivotaltracker.com/story/show/98677186"},{"kind":"story","id":98677188,"project_id":<TRACKERPROJECT>,"name":"Full
         production launch","story_type":"release","current_state":"unstarted","requested_by_id":379075,"owner_ids":[],"labels":[],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:13Z","url":"https://www.pivotaltracker.com/story/show/98677188"}],"start":"2016-04-11T00:00:00Z","finish":"2016-04-18T00:00:00Z"}]'
     http_version: 
-  recorded_at: Wed, 29 Jul 2015 14:47:38 GMT
+  recorded_at: Wed, 29 Jul 2015 14:48:49 GMT
 - request:
     method: get
     uri: https://www.pivotaltracker.com/services/v5/projects/<TRACKERPROJECT>
@@ -423,11 +423,11 @@ http_interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 1d32aef3040af88b11541eb9e2bace80
+      - e7ba9c33a66d1c014c895043ebaa1746
       X-Runtime:
-      - '0.044229'
+      - '0.046272'
       Date:
-      - Wed, 29 Jul 2015 14:47:39 GMT
+      - Wed, 29 Jul 2015 14:48:50 GMT
       X-Rack-Cache:
       - miss
       X-Powered-By:
@@ -450,342 +450,55 @@ http_interactions:
         is a demo project, created by Tracker, with example stories for a simple shopping
         web site.","enable_incoming_emails":true,"initial_velocity":10,"public":false,"atom_enabled":false,"project_type":"demo","start_time":"2015-06-22T00:00:00Z","created_at":"2015-07-08T18:57:11Z","updated_at":"2015-07-08T19:01:19Z","account_id":774272,"current_iteration_number":6,"enable_following":true}'
     http_version: 
-  recorded_at: Wed, 29 Jul 2015 14:47:38 GMT
+  recorded_at: Wed, 29 Jul 2015 14:48:50 GMT
 - request:
-    method: get
-    uri: https://www.pivotaltracker.com/services/v5/projects/<TRACKERPROJECT>/iterations?scope=current_backlog
+    method: post
+    uri: https://www.pivotaltracker.com/services/v5/projects/<TRACKERPROJECT>/stories
     body:
-      encoding: US-ASCII
-      string: ''
+      encoding: UTF-8
+      string: '{"name":"As a customer, I want foo bar","description":"As an boss,
+        I want another drink, so that I get drunk","after_id":null}'
     headers:
       User-Agent:
       - Ruby/2.2.2 (x86_64-darwin14; ruby) TrackerApi/0.2.10 Faraday/0.9.1
       X-Trackertoken:
       - "<TRACKERAPITOKEN>"
+      Content-Type:
+      - application/json
   response:
     status:
-      code: 200
+      code: 400
       message: ''
     headers:
       Content-Type:
       - application/json; charset=utf-8
       Status:
-      - 200 OK
-      X-Tracker-Project-Version:
-      - '60'
-      X-Tracker-Pagination-Total:
-      - '38'
-      X-Tracker-Pagination-Offset:
-      - '0'
-      X-Tracker-Pagination-Limit:
-      - '10'
-      X-Tracker-Pagination-Returned:
-      - '10'
+      - 400 Bad Request
       X-Ua-Compatible:
       - IE=Edge,chrome=1
-      Etag:
-      - '"a45abde516f1b05b1d3db453cf2f1c66"'
       Cache-Control:
-      - max-age=0, private, must-revalidate
+      - no-cache
       X-Request-Id:
-      - bd1af1601a425a987b811a35a2b82b7b
+      - 330a1556a1a4abd09826907ed6787375
       X-Runtime:
-      - '0.036562'
+      - '0.167289'
       Date:
-      - Wed, 29 Jul 2015 14:47:39 GMT
+      - Wed, 29 Jul 2015 14:48:51 GMT
       X-Rack-Cache:
-      - miss
+      - invalidate, pass
       X-Powered-By:
       - Phusion Passenger 4.0.41
       Server:
       - nginx/1.6.0 + Phusion Passenger 4.0.41
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Credentials:
-      - 'false'
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, DELETE, OPTIONS
-      Access-Control-Allow-Headers:
-      - X-TrackerToken,DNT,X-Mx-ReqToken,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,X-Tracker-Warn-Unless-Project-Version-Is
-      X-Tracker-Client-Pinger-Interval:
-      - '12'
     body:
       encoding: UTF-8
-      string: '[{"kind":"iteration","number":6,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[{"kind":"story","id":98677104,"project_id":<TRACKERPROJECT>,"name":"Shopper
-        should be able to view contents of shopping cart","description":"Cart icon
-        in top right corner, with a number indicating how many items in cart","story_type":"feature","current_state":"delivered","estimate":2,"requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166940,"project_id":<TRACKERPROJECT>,"name":"cart","created_at":"2015-07-08T18:57:11Z","updated_at":"2015-07-08T18:57:11Z"},{"kind":"label","id":12166936,"project_id":<TRACKERPROJECT>,"name":"shopping","created_at":"2015-07-08T18:57:11Z","updated_at":"2015-07-08T18:57:11Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:11Z","url":"https://www.pivotaltracker.com/story/show/98677104"},{"kind":"story","id":98677106,"project_id":<TRACKERPROJECT>,"name":"Shopper
-        should be able to remove product from shopping cart","story_type":"feature","current_state":"delivered","estimate":1,"requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166940,"project_id":<TRACKERPROJECT>,"name":"cart","created_at":"2015-07-08T18:57:11Z","updated_at":"2015-07-08T18:57:11Z"},{"kind":"label","id":12166936,"project_id":<TRACKERPROJECT>,"name":"shopping","created_at":"2015-07-08T18:57:11Z","updated_at":"2015-07-08T18:57:11Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:11Z","url":"https://www.pivotaltracker.com/story/show/98677106"},{"kind":"story","id":98677108,"project_id":<TRACKERPROJECT>,"name":"Cart
-        manipulation should be AJAXy","story_type":"feature","current_state":"finished","estimate":1,"requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166940,"project_id":<TRACKERPROJECT>,"name":"cart","created_at":"2015-07-08T18:57:11Z","updated_at":"2015-07-08T18:57:11Z"},{"kind":"label","id":12166936,"project_id":<TRACKERPROJECT>,"name":"shopping","created_at":"2015-07-08T18:57:11Z","updated_at":"2015-07-08T18:57:11Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677108"},{"kind":"story","id":98677110,"project_id":<TRACKERPROJECT>,"name":"Some
-        product photos not scaled properly when browsing products","story_type":"bug","current_state":"started","requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166936,"project_id":<TRACKERPROJECT>,"name":"shopping","created_at":"2015-07-08T18:57:11Z","updated_at":"2015-07-08T18:57:11Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677110"},{"kind":"story","id":98677112,"project_id":<TRACKERPROJECT>,"name":"Shopper
-        should be able to recommend a product to a friend","description":"Prompt for
-        email address and personalized message, send email with product details and
-        message","story_type":"feature","current_state":"started","estimate":1,"requested_by_id":379075,"owned_by_id":379075,"owner_ids":[379075],"labels":[{"kind":"label","id":12166936,"project_id":<TRACKERPROJECT>,"name":"shopping","created_at":"2015-07-08T18:57:11Z","updated_at":"2015-07-08T18:57:11Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-21T17:01:29Z","url":"https://www.pivotaltracker.com/story/show/98677112"}],"start":"2015-07-27T00:00:00Z","finish":"2015-08-03T00:00:00Z"},{"kind":"iteration","number":7,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[{"kind":"story","id":98988674,"project_id":<TRACKERPROJECT>,"name":"As
-        a customer, I want slack integration","description":"\nAs an customer, I want
-        slack integration, so that I can stop importing invoices manually.\n\n## Acceptance
-        Criteria\n\n* \n* \n","story_type":"feature","current_state":"unstarted","requested_by_id":379075,"owner_ids":[],"labels":[],"created_at":"2015-07-13T21:28:52Z","updated_at":"2015-07-22T23:10:14Z","url":"https://www.pivotaltracker.com/story/show/98988674"},{"kind":"story","id":99533038,"project_id":<TRACKERPROJECT>,"name":"Adding
-        a new story to the list","description":"This is a new story","story_type":"feature","current_state":"unstarted","requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12276718,"project_id":<TRACKERPROJECT>,"name":"with_label","created_at":"2015-07-21T16:59:37Z","updated_at":"2015-07-21T16:59:37Z"}],"created_at":"2015-07-21T16:59:37Z","updated_at":"2015-07-22T23:06:53Z","url":"https://www.pivotaltracker.com/story/show/99533038"},{"kind":"story","id":99432476,"project_id":<TRACKERPROJECT>,"name":"As
-        a RMS user, I want everything","description":"\nAs an RMS user, I want everything,
-        so that make money.\n\n## Acceptance Criteria\n\n* \n* \n","story_type":"feature","current_state":"unstarted","requested_by_id":379075,"owner_ids":[],"labels":[],"created_at":"2015-07-20T16:23:00Z","updated_at":"2015-07-20T20:08:54Z","url":"https://www.pivotaltracker.com/story/show/99432476"}],"start":"2015-08-03T00:00:00Z","finish":"2015-08-10T00:00:00Z"},{"kind":"iteration","number":8,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[],"start":"2015-08-10T00:00:00Z","finish":"2015-08-17T00:00:00Z"},{"kind":"iteration","number":9,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[{"kind":"story","id":99380320,"project_id":<TRACKERPROJECT>,"name":"As
-        a another customer, I want stuff","description":"\nAs an another customer,
-        I want stuff, so that its very important.\n\n## Acceptance Criteria\n\n* \n*
-        \n","story_type":"feature","current_state":"unstarted","estimate":3,"requested_by_id":379075,"owner_ids":[],"labels":[],"created_at":"2015-07-19T23:38:54Z","updated_at":"2015-07-21T17:02:02Z","url":"https://www.pivotaltracker.com/story/show/99380320"},{"kind":"story","id":98677114,"project_id":<TRACKERPROJECT>,"name":"configure
-        solr for full text searching","story_type":"chore","current_state":"unstarted","requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166942,"project_id":<TRACKERPROJECT>,"name":"search","created_at":"2015-07-08T18:57:12Z","updated_at":"2015-07-08T18:57:12Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677114"},{"kind":"story","id":98688698,"project_id":<TRACKERPROJECT>,"name":"trying
-        to insert after configure solr","story_type":"feature","current_state":"unstarted","requested_by_id":379075,"owner_ids":[],"labels":[],"created_at":"2015-07-08T21:01:30Z","updated_at":"2015-07-08T21:01:30Z","url":"https://www.pivotaltracker.com/story/show/98688698"},{"kind":"story","id":99852954,"project_id":<TRACKERPROJECT>,"name":"As
-        a customer, I want slack integration","description":"\nAs an customer, I want
-        slack integration, so that I can stop importing invoices manually.\n\n## Acceptance
-        Criteria\n\n* \n* \n","story_type":"feature","current_state":"unstarted","requested_by_id":379075,"owner_ids":[],"labels":[],"created_at":"2015-07-26T02:58:46Z","updated_at":"2015-07-26T02:58:46Z","url":"https://www.pivotaltracker.com/story/show/99852954"}],"start":"2015-08-17T00:00:00Z","finish":"2015-08-24T00:00:00Z"},{"kind":"iteration","number":10,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[],"start":"2015-08-24T00:00:00Z","finish":"2015-08-31T00:00:00Z"},{"kind":"iteration","number":11,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[],"start":"2015-08-31T00:00:00Z","finish":"2015-09-07T00:00:00Z"},{"kind":"iteration","number":12,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[{"kind":"story","id":98677116,"project_id":<TRACKERPROJECT>,"name":"Shopper
-        should be able to search for product","description":"One search field, search
-        should look through product name, description, and SKU","story_type":"feature","current_state":"unstarted","estimate":3,"requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166942,"project_id":<TRACKERPROJECT>,"name":"search","created_at":"2015-07-08T18:57:12Z","updated_at":"2015-07-08T18:57:12Z"},{"kind":"label","id":12166936,"project_id":<TRACKERPROJECT>,"name":"shopping","created_at":"2015-07-08T18:57:11Z","updated_at":"2015-07-08T18:57:11Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677116"},{"kind":"story","id":98677118,"project_id":<TRACKERPROJECT>,"name":"Initial
-        demo to investors","story_type":"release","current_state":"unstarted","requested_by_id":379075,"owner_ids":[],"labels":[],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677118"}],"start":"2015-09-07T00:00:00Z","finish":"2015-09-14T00:00:00Z"},{"kind":"iteration","number":13,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[{"kind":"story","id":98677120,"project_id":<TRACKERPROJECT>,"name":"Shopper
-        should be able to enter credit card information and shipping address","story_type":"feature","current_state":"unstarted","estimate":1,"requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166944,"project_id":<TRACKERPROJECT>,"name":"checkout","created_at":"2015-07-08T18:57:12Z","updated_at":"2015-07-08T18:57:12Z"},{"kind":"label","id":12166936,"project_id":<TRACKERPROJECT>,"name":"shopping","created_at":"2015-07-08T18:57:11Z","updated_at":"2015-07-08T18:57:11Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677120"},{"kind":"story","id":98677122,"project_id":<TRACKERPROJECT>,"name":"Integrate
-        with payment gateway","story_type":"chore","current_state":"unstarted","requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166944,"project_id":<TRACKERPROJECT>,"name":"checkout","created_at":"2015-07-08T18:57:12Z","updated_at":"2015-07-08T18:57:12Z"},{"kind":"label","id":12166936,"project_id":<TRACKERPROJECT>,"name":"shopping","created_at":"2015-07-08T18:57:11Z","updated_at":"2015-07-08T18:57:11Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677122"}],"start":"2015-09-14T00:00:00Z","finish":"2015-09-21T00:00:00Z"},{"kind":"iteration","number":14,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[],"start":"2015-09-21T00:00:00Z","finish":"2015-09-28T00:00:00Z"},{"kind":"iteration","number":15,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[],"start":"2015-09-28T00:00:00Z","finish":"2015-10-05T00:00:00Z"}]'
+      string: '{"code":"invalid_parameter","kind":"error","error":"One or more request
+        parameters was missing or invalid.","requirement":"Command parameters that
+        directly set properties of resources must be identical to the result value.","general_problem":"Got
+        bad values for the following parameter(s):  none of the supplied object-move
+        parameters match the generated results (''after_id'' parameter was  but result
+        was 98677188)","possible_fix":"Normalize the parameter values before sending
+        them to the server."}'
     http_version: 
-  recorded_at: Wed, 29 Jul 2015 14:47:38 GMT
-- request:
-    method: get
-    uri: https://www.pivotaltracker.com/services/v5/projects/<TRACKERPROJECT>/iterations?limit=10&offset=10&scope=current_backlog
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - Ruby/2.2.2 (x86_64-darwin14; ruby) TrackerApi/0.2.10 Faraday/0.9.1
-      X-Trackertoken:
-      - "<TRACKERAPITOKEN>"
-  response:
-    status:
-      code: 200
-      message: ''
-    headers:
-      Content-Type:
-      - application/json; charset=utf-8
-      Status:
-      - 200 OK
-      X-Tracker-Project-Version:
-      - '60'
-      X-Tracker-Pagination-Total:
-      - '38'
-      X-Tracker-Pagination-Offset:
-      - '10'
-      X-Tracker-Pagination-Limit:
-      - '10'
-      X-Tracker-Pagination-Returned:
-      - '10'
-      X-Ua-Compatible:
-      - IE=Edge,chrome=1
-      Etag:
-      - '"605d5ce640c91e3bf2a19a2d44f31c02"'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      X-Request-Id:
-      - f7e09238d98fffcf023d74d8d8f69691
-      X-Runtime:
-      - '0.037959'
-      Date:
-      - Wed, 29 Jul 2015 14:47:39 GMT
-      X-Rack-Cache:
-      - miss
-      X-Powered-By:
-      - Phusion Passenger 4.0.41
-      Server:
-      - nginx/1.6.0 + Phusion Passenger 4.0.41
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Credentials:
-      - 'false'
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, DELETE, OPTIONS
-      Access-Control-Allow-Headers:
-      - X-TrackerToken,DNT,X-Mx-ReqToken,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,X-Tracker-Warn-Unless-Project-Version-Is
-      X-Tracker-Client-Pinger-Interval:
-      - '12'
-    body:
-      encoding: UTF-8
-      string: '[{"kind":"iteration","number":16,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[{"kind":"story","id":98677124,"project_id":<TRACKERPROJECT>,"name":"When
-        shopper submits order, authorize total product amount from payment gateway","story_type":"feature","current_state":"unstarted","estimate":3,"requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166944,"project_id":<TRACKERPROJECT>,"name":"checkout","created_at":"2015-07-08T18:57:12Z","updated_at":"2015-07-08T18:57:12Z"},{"kind":"label","id":12166946,"project_id":<TRACKERPROJECT>,"name":"needs
-        discussion","created_at":"2015-07-08T18:57:12Z","updated_at":"2015-07-08T18:57:12Z"},{"kind":"label","id":12166936,"project_id":<TRACKERPROJECT>,"name":"shopping","created_at":"2015-07-08T18:57:11Z","updated_at":"2015-07-08T18:57:11Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677124"}],"start":"2015-10-05T00:00:00Z","finish":"2015-10-12T00:00:00Z"},{"kind":"iteration","number":17,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[{"kind":"story","id":98677126,"project_id":<TRACKERPROJECT>,"name":"If
-        system fails to authorize payment amount, display error message to shopper","story_type":"feature","current_state":"unstarted","estimate":1,"requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166944,"project_id":<TRACKERPROJECT>,"name":"checkout","created_at":"2015-07-08T18:57:12Z","updated_at":"2015-07-08T18:57:12Z"},{"kind":"label","id":12166936,"project_id":<TRACKERPROJECT>,"name":"shopping","created_at":"2015-07-08T18:57:11Z","updated_at":"2015-07-08T18:57:11Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677126"}],"start":"2015-10-12T00:00:00Z","finish":"2015-10-19T00:00:00Z"},{"kind":"iteration","number":18,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[{"kind":"story","id":98677128,"project_id":<TRACKERPROJECT>,"name":"If
-        authorization is successful, show order number and confirmation message to
-        shopper","story_type":"feature","current_state":"unstarted","estimate":1,"requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166944,"project_id":<TRACKERPROJECT>,"name":"checkout","created_at":"2015-07-08T18:57:12Z","updated_at":"2015-07-08T18:57:12Z"},{"kind":"label","id":12166936,"project_id":<TRACKERPROJECT>,"name":"shopping","created_at":"2015-07-08T18:57:11Z","updated_at":"2015-07-08T18:57:11Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677128"},{"kind":"story","id":98688754,"project_id":<TRACKERPROJECT>,"name":"Foo
-        Bar 2","story_type":"feature","current_state":"unstarted","requested_by_id":379075,"owner_ids":[],"labels":[],"created_at":"2015-07-08T21:02:19Z","updated_at":"2015-07-08T21:02:19Z","url":"https://www.pivotaltracker.com/story/show/98688754"}],"start":"2015-10-19T00:00:00Z","finish":"2015-10-26T00:00:00Z"},{"kind":"iteration","number":19,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[],"start":"2015-10-26T00:00:00Z","finish":"2015-11-02T00:00:00Z"},{"kind":"iteration","number":20,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[{"kind":"story","id":99260190,"project_id":<TRACKERPROJECT>,"name":"As
-        a fdoo, I want bar","description":"\nAs an fdoo, I want bar, so that baz.\n\n##
-        Acceptance Criteria\n\n* \n* \n","story_type":"feature","current_state":"unstarted","estimate":2,"requested_by_id":379075,"owner_ids":[],"labels":[],"created_at":"2015-07-16T20:49:18Z","updated_at":"2015-07-16T21:00:42Z","url":"https://www.pivotaltracker.com/story/show/99260190"}],"start":"2015-11-02T00:00:00Z","finish":"2015-11-09T00:00:00Z"},{"kind":"iteration","number":21,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[{"kind":"story","id":98677130,"project_id":<TRACKERPROJECT>,"name":"Send
-        notification email of order placement to admin","story_type":"feature","current_state":"unstarted","estimate":1,"requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166934,"project_id":<TRACKERPROJECT>,"name":"admin","created_at":"2015-07-08T18:57:11Z","updated_at":"2015-07-08T18:57:11Z"},{"kind":"label","id":12166944,"project_id":<TRACKERPROJECT>,"name":"checkout","created_at":"2015-07-08T18:57:12Z","updated_at":"2015-07-08T18:57:12Z"},{"kind":"label","id":12166936,"project_id":<TRACKERPROJECT>,"name":"shopping","created_at":"2015-07-08T18:57:11Z","updated_at":"2015-07-08T18:57:11Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677130"}],"start":"2015-11-09T00:00:00Z","finish":"2015-11-16T00:00:00Z"},{"kind":"iteration","number":22,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[],"start":"2015-11-16T00:00:00Z","finish":"2015-11-23T00:00:00Z"},{"kind":"iteration","number":23,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[{"kind":"story","id":98677132,"project_id":<TRACKERPROJECT>,"name":"Shopper
-        should be able to check status of order by entering name and order number","story_type":"feature","current_state":"unstarted","estimate":2,"requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166948,"project_id":<TRACKERPROJECT>,"name":"orders","created_at":"2015-07-08T18:57:12Z","updated_at":"2015-07-08T18:57:12Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677132"}],"start":"2015-11-23T00:00:00Z","finish":"2015-11-30T00:00:00Z"},{"kind":"iteration","number":24,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[{"kind":"story","id":98677134,"project_id":<TRACKERPROJECT>,"name":"Shopper
-        should be able to ask question about order","description":"When checking status
-        of order, shopper should have the option to ask a question. This should send
-        email to admin.","story_type":"feature","current_state":"unstarted","estimate":1,"requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166948,"project_id":<TRACKERPROJECT>,"name":"orders","created_at":"2015-07-08T18:57:12Z","updated_at":"2015-07-08T18:57:12Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677134"}],"start":"2015-11-30T00:00:00Z","finish":"2015-12-07T00:00:00Z"},{"kind":"iteration","number":25,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[{"kind":"story","id":98677136,"project_id":<TRACKERPROJECT>,"name":"Admin
-        can review all order questions and send responses to shoppers","story_type":"feature","current_state":"unstarted","estimate":1,"requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166934,"project_id":<TRACKERPROJECT>,"name":"admin","created_at":"2015-07-08T18:57:11Z","updated_at":"2015-07-08T18:57:11Z"},{"kind":"label","id":12166948,"project_id":<TRACKERPROJECT>,"name":"orders","created_at":"2015-07-08T18:57:12Z","updated_at":"2015-07-08T18:57:12Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677136"},{"kind":"story","id":98677138,"project_id":<TRACKERPROJECT>,"name":"Set
-        up Engine Yard production environment","story_type":"chore","current_state":"unstarted","requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166932,"project_id":<TRACKERPROJECT>,"name":"deployment","created_at":"2015-07-08T18:57:11Z","updated_at":"2015-07-08T18:57:11Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677138"},{"kind":"story","id":98677140,"project_id":<TRACKERPROJECT>,"name":"Beta
-        launch","story_type":"release","current_state":"unstarted","deadline":"2015-07-27T00:00:00Z","requested_by_id":379075,"owner_ids":[],"labels":[],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677140"}],"start":"2015-12-07T00:00:00Z","finish":"2015-12-14T00:00:00Z"}]'
-    http_version: 
-  recorded_at: Wed, 29 Jul 2015 14:47:39 GMT
-- request:
-    method: get
-    uri: https://www.pivotaltracker.com/services/v5/projects/<TRACKERPROJECT>/iterations?limit=10&offset=20&scope=current_backlog
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - Ruby/2.2.2 (x86_64-darwin14; ruby) TrackerApi/0.2.10 Faraday/0.9.1
-      X-Trackertoken:
-      - "<TRACKERAPITOKEN>"
-  response:
-    status:
-      code: 200
-      message: ''
-    headers:
-      Content-Type:
-      - application/json; charset=utf-8
-      Status:
-      - 200 OK
-      X-Tracker-Project-Version:
-      - '60'
-      X-Tracker-Pagination-Total:
-      - '38'
-      X-Tracker-Pagination-Offset:
-      - '20'
-      X-Tracker-Pagination-Limit:
-      - '10'
-      X-Tracker-Pagination-Returned:
-      - '10'
-      X-Ua-Compatible:
-      - IE=Edge,chrome=1
-      Etag:
-      - '"6d672d053b6acbac48e7708ae2286b55"'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      X-Request-Id:
-      - 501d693ac9a04b7d8fc98ea3a27222ca
-      X-Runtime:
-      - '0.038911'
-      Date:
-      - Wed, 29 Jul 2015 14:47:40 GMT
-      X-Rack-Cache:
-      - miss
-      X-Powered-By:
-      - Phusion Passenger 4.0.41
-      Server:
-      - nginx/1.6.0 + Phusion Passenger 4.0.41
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Credentials:
-      - 'false'
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, DELETE, OPTIONS
-      Access-Control-Allow-Headers:
-      - X-TrackerToken,DNT,X-Mx-ReqToken,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,X-Tracker-Warn-Unless-Project-Version-Is
-      X-Tracker-Client-Pinger-Interval:
-      - '12'
-    body:
-      encoding: UTF-8
-      string: '[{"kind":"iteration","number":26,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[],"start":"2015-12-14T00:00:00Z","finish":"2015-12-21T00:00:00Z"},{"kind":"iteration","number":27,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[{"kind":"story","id":98677142,"project_id":<TRACKERPROJECT>,"name":"Shopper
-        should be able to sign up for an account with email address","story_type":"feature","current_state":"unstarted","estimate":2,"requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166950,"project_id":<TRACKERPROJECT>,"name":"signup
-        / signin","created_at":"2015-07-08T18:57:12Z","updated_at":"2015-07-08T18:57:12Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677142"}],"start":"2015-12-21T00:00:00Z","finish":"2015-12-28T00:00:00Z"},{"kind":"iteration","number":28,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[{"kind":"story","id":98677144,"project_id":<TRACKERPROJECT>,"name":"Shopper
-        should be able to reset forgotten password","story_type":"feature","current_state":"unstarted","estimate":1,"requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166950,"project_id":<TRACKERPROJECT>,"name":"signup
-        / signin","created_at":"2015-07-08T18:57:12Z","updated_at":"2015-07-08T18:57:12Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677144"}],"start":"2015-12-28T00:00:00Z","finish":"2016-01-04T00:00:00Z"},{"kind":"iteration","number":29,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[{"kind":"story","id":98677146,"project_id":<TRACKERPROJECT>,"name":"Shopper
-        should be able to log out","story_type":"feature","current_state":"unstarted","estimate":1,"requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166950,"project_id":<TRACKERPROJECT>,"name":"signup
-        / signin","created_at":"2015-07-08T18:57:12Z","updated_at":"2015-07-08T18:57:12Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677146"}],"start":"2016-01-04T00:00:00Z","finish":"2016-01-11T00:00:00Z"},{"kind":"iteration","number":30,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[{"kind":"story","id":98677148,"project_id":<TRACKERPROJECT>,"name":"When
-        checking out, shopper should have the option to sign in to their account","story_type":"feature","current_state":"unstarted","estimate":1,"requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166950,"project_id":<TRACKERPROJECT>,"name":"signup
-        / signin","created_at":"2015-07-08T18:57:12Z","updated_at":"2015-07-08T18:57:12Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677148"}],"start":"2016-01-11T00:00:00Z","finish":"2016-01-18T00:00:00Z"},{"kind":"iteration","number":31,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[{"kind":"story","id":98677150,"project_id":<TRACKERPROJECT>,"name":"Signed
-        in shopper should be able to review order history","description":"Show orders
-        in last 60 days, with link to show older orders","story_type":"feature","current_state":"unstarted","estimate":1,"requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166952,"project_id":<TRACKERPROJECT>,"name":"shopper
-        accounts","created_at":"2015-07-08T18:57:12Z","updated_at":"2015-07-08T18:57:12Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677150"}],"start":"2016-01-18T00:00:00Z","finish":"2016-01-25T00:00:00Z"},{"kind":"iteration","number":32,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[],"start":"2016-01-25T00:00:00Z","finish":"2016-02-01T00:00:00Z"},{"kind":"iteration","number":33,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[{"kind":"story","id":98677152,"project_id":<TRACKERPROJECT>,"name":"Signed
-        in shopper should be able to save credit card and address information used
-        in checkout","description":"Credit card numbers should be stored encrypted","story_type":"feature","current_state":"unstarted","estimate":2,"requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166952,"project_id":<TRACKERPROJECT>,"name":"shopper
-        accounts","created_at":"2015-07-08T18:57:12Z","updated_at":"2015-07-08T18:57:12Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677152"}],"start":"2016-02-01T00:00:00Z","finish":"2016-02-08T00:00:00Z"},{"kind":"iteration","number":34,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[{"kind":"story","id":98677154,"project_id":<TRACKERPROJECT>,"name":"Signed
-        in shopper should be able to save product to favorites","story_type":"feature","current_state":"unstarted","estimate":1,"requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166952,"project_id":<TRACKERPROJECT>,"name":"shopper
-        accounts","created_at":"2015-07-08T18:57:12Z","updated_at":"2015-07-08T18:57:12Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677154"}],"start":"2016-02-08T00:00:00Z","finish":"2016-02-15T00:00:00Z"},{"kind":"iteration","number":35,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[{"kind":"story","id":98677156,"project_id":<TRACKERPROJECT>,"name":"Signed
-        in shopper should be able to review and remove product from favorites","story_type":"feature","current_state":"unstarted","estimate":1,"requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166952,"project_id":<TRACKERPROJECT>,"name":"shopper
-        accounts","created_at":"2015-07-08T18:57:12Z","updated_at":"2015-07-08T18:57:12Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677156"},{"kind":"story","id":98677158,"project_id":<TRACKERPROJECT>,"name":"Provide
-        feedback to designer about look/feel of site","story_type":"chore","current_state":"unstarted","requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166954,"project_id":<TRACKERPROJECT>,"name":"design","created_at":"2015-07-08T18:57:12Z","updated_at":"2015-07-08T18:57:12Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677158"}],"start":"2016-02-15T00:00:00Z","finish":"2016-02-22T00:00:00Z"}]'
-    http_version: 
-  recorded_at: Wed, 29 Jul 2015 14:47:39 GMT
-- request:
-    method: get
-    uri: https://www.pivotaltracker.com/services/v5/projects/<TRACKERPROJECT>/iterations?limit=10&offset=30&scope=current_backlog
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - Ruby/2.2.2 (x86_64-darwin14; ruby) TrackerApi/0.2.10 Faraday/0.9.1
-      X-Trackertoken:
-      - "<TRACKERAPITOKEN>"
-  response:
-    status:
-      code: 200
-      message: ''
-    headers:
-      Content-Type:
-      - application/json; charset=utf-8
-      Status:
-      - 200 OK
-      X-Tracker-Project-Version:
-      - '60'
-      X-Tracker-Pagination-Total:
-      - '38'
-      X-Tracker-Pagination-Offset:
-      - '30'
-      X-Tracker-Pagination-Limit:
-      - '10'
-      X-Tracker-Pagination-Returned:
-      - '8'
-      X-Ua-Compatible:
-      - IE=Edge,chrome=1
-      Etag:
-      - '"33834fa7c8aa742f6387c9d3c31fd6c5"'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      X-Request-Id:
-      - 6eae5d9de292e214b9ab69e213d8d8f9
-      X-Runtime:
-      - '0.042543'
-      Date:
-      - Wed, 29 Jul 2015 14:47:40 GMT
-      X-Rack-Cache:
-      - miss
-      X-Powered-By:
-      - Phusion Passenger 4.0.41
-      Server:
-      - nginx/1.6.0 + Phusion Passenger 4.0.41
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Credentials:
-      - 'false'
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, DELETE, OPTIONS
-      Access-Control-Allow-Headers:
-      - X-TrackerToken,DNT,X-Mx-ReqToken,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,X-Tracker-Warn-Unless-Project-Version-Is
-      X-Tracker-Client-Pinger-Interval:
-      - '12'
-    body:
-      encoding: UTF-8
-      string: '[{"kind":"iteration","number":36,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[],"start":"2016-02-22T00:00:00Z","finish":"2016-02-29T00:00:00Z"},{"kind":"iteration","number":37,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[],"start":"2016-02-29T00:00:00Z","finish":"2016-03-07T00:00:00Z"},{"kind":"iteration","number":38,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[{"kind":"story","id":98677160,"project_id":<TRACKERPROJECT>,"name":"Apply
-        styling to all shopper facing parts of the site, based on assets from designer","story_type":"feature","current_state":"unstarted","estimate":3,"requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166954,"project_id":<TRACKERPROJECT>,"name":"design","created_at":"2015-07-08T18:57:12Z","updated_at":"2015-07-08T18:57:12Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677160"}],"start":"2016-03-07T00:00:00Z","finish":"2016-03-14T00:00:00Z"},{"kind":"iteration","number":39,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[],"start":"2016-03-14T00:00:00Z","finish":"2016-03-21T00:00:00Z"},{"kind":"iteration","number":40,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[{"kind":"story","id":98677162,"project_id":<TRACKERPROJECT>,"name":"Signed
-        in shopper should be able to post product reviews","story_type":"feature","current_state":"unstarted","estimate":2,"requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166956,"project_id":<TRACKERPROJECT>,"name":"user
-        generated content","created_at":"2015-07-08T18:57:12Z","updated_at":"2015-07-08T18:57:12Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677162"}],"start":"2016-03-21T00:00:00Z","finish":"2016-03-28T00:00:00Z"},{"kind":"iteration","number":41,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[{"kind":"story","id":98677164,"project_id":<TRACKERPROJECT>,"name":"Signed
-        in shopper should be able to rate product, by choosing 1-5 stars","story_type":"feature","current_state":"unstarted","estimate":1,"requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166956,"project_id":<TRACKERPROJECT>,"name":"user
-        generated content","created_at":"2015-07-08T18:57:12Z","updated_at":"2015-07-08T18:57:12Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677164"}],"start":"2016-03-28T00:00:00Z","finish":"2016-04-04T00:00:00Z"},{"kind":"iteration","number":42,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[{"kind":"story","id":98677166,"project_id":<TRACKERPROJECT>,"name":"When
-        shopper is browsing products, show average product rating and number of reviews
-        next to each product","story_type":"feature","current_state":"unstarted","estimate":1,"requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166956,"project_id":<TRACKERPROJECT>,"name":"user
-        generated content","created_at":"2015-07-08T18:57:12Z","updated_at":"2015-07-08T18:57:12Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:13Z","url":"https://www.pivotaltracker.com/story/show/98677166"}],"start":"2016-04-04T00:00:00Z","finish":"2016-04-11T00:00:00Z"},{"kind":"iteration","number":43,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[{"kind":"story","id":98677168,"project_id":<TRACKERPROJECT>,"name":"Shopper
-        should be able to read reviews for a product","story_type":"feature","current_state":"unstarted","estimate":1,"requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166956,"project_id":<TRACKERPROJECT>,"name":"user
-        generated content","created_at":"2015-07-08T18:57:12Z","updated_at":"2015-07-08T18:57:12Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:13Z","url":"https://www.pivotaltracker.com/story/show/98677168"},{"kind":"story","id":98677170,"project_id":<TRACKERPROJECT>,"name":"Admin
-        should be able to mark a product as featured","story_type":"feature","current_state":"unstarted","requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166934,"project_id":<TRACKERPROJECT>,"name":"admin","created_at":"2015-07-08T18:57:11Z","updated_at":"2015-07-08T18:57:11Z"},{"kind":"label","id":12166958,"project_id":<TRACKERPROJECT>,"name":"featured
-        products","created_at":"2015-07-08T18:57:13Z","updated_at":"2015-07-08T18:57:13Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:13Z","url":"https://www.pivotaltracker.com/story/show/98677170"},{"kind":"story","id":98677172,"project_id":<TRACKERPROJECT>,"name":"Featured
-        products should appear on the site landing page","story_type":"feature","current_state":"unstarted","requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166958,"project_id":<TRACKERPROJECT>,"name":"featured
-        products","created_at":"2015-07-08T18:57:13Z","updated_at":"2015-07-08T18:57:13Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:13Z","url":"https://www.pivotaltracker.com/story/show/98677172"},{"kind":"story","id":98677174,"project_id":<TRACKERPROJECT>,"name":"Admin
-        should be able to create and edit blog articles","story_type":"feature","current_state":"unstarted","requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166934,"project_id":<TRACKERPROJECT>,"name":"admin","created_at":"2015-07-08T18:57:11Z","updated_at":"2015-07-08T18:57:11Z"},{"kind":"label","id":12166960,"project_id":<TRACKERPROJECT>,"name":"blog","created_at":"2015-07-08T18:57:13Z","updated_at":"2015-07-08T18:57:13Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:13Z","url":"https://www.pivotaltracker.com/story/show/98677174"},{"kind":"story","id":98677176,"project_id":<TRACKERPROJECT>,"name":"Admin
-        should be able to save blog articles in draft mode","story_type":"feature","current_state":"unstarted","requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166934,"project_id":<TRACKERPROJECT>,"name":"admin","created_at":"2015-07-08T18:57:11Z","updated_at":"2015-07-08T18:57:11Z"},{"kind":"label","id":12166960,"project_id":<TRACKERPROJECT>,"name":"blog","created_at":"2015-07-08T18:57:13Z","updated_at":"2015-07-08T18:57:13Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:13Z","url":"https://www.pivotaltracker.com/story/show/98677176"},{"kind":"story","id":98677178,"project_id":<TRACKERPROJECT>,"name":"Published
-        blog articles should appear on the site","story_type":"feature","current_state":"unstarted","requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166960,"project_id":<TRACKERPROJECT>,"name":"blog","created_at":"2015-07-08T18:57:13Z","updated_at":"2015-07-08T18:57:13Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:13Z","url":"https://www.pivotaltracker.com/story/show/98677178"},{"kind":"story","id":98677180,"project_id":<TRACKERPROJECT>,"name":"People
-        should be able to subscribe to blog via RSS and Atom","story_type":"feature","current_state":"unstarted","requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166960,"project_id":<TRACKERPROJECT>,"name":"blog","created_at":"2015-07-08T18:57:13Z","updated_at":"2015-07-08T18:57:13Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:13Z","url":"https://www.pivotaltracker.com/story/show/98677180"},{"kind":"story","id":98677182,"project_id":<TRACKERPROJECT>,"name":"Admin
-        should be able to view monthly sales report","story_type":"feature","current_state":"unstarted","requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166934,"project_id":<TRACKERPROJECT>,"name":"admin","created_at":"2015-07-08T18:57:11Z","updated_at":"2015-07-08T18:57:11Z"},{"kind":"label","id":12166962,"project_id":<TRACKERPROJECT>,"name":"reporting","created_at":"2015-07-08T18:57:13Z","updated_at":"2015-07-08T18:57:13Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:13Z","url":"https://www.pivotaltracker.com/story/show/98677182"},{"kind":"story","id":98677184,"project_id":<TRACKERPROJECT>,"name":"Admin
-        should be able to export orders as CSV file, based on date range and order
-        status","story_type":"feature","current_state":"unstarted","requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166934,"project_id":<TRACKERPROJECT>,"name":"admin","created_at":"2015-07-08T18:57:11Z","updated_at":"2015-07-08T18:57:11Z"},{"kind":"label","id":12166962,"project_id":<TRACKERPROJECT>,"name":"reporting","created_at":"2015-07-08T18:57:13Z","updated_at":"2015-07-08T18:57:13Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:13Z","url":"https://www.pivotaltracker.com/story/show/98677184"},{"kind":"story","id":98677186,"project_id":<TRACKERPROJECT>,"name":"Request
-        higher number of production slices, for scaling","story_type":"chore","current_state":"unstarted","requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166932,"project_id":<TRACKERPROJECT>,"name":"deployment","created_at":"2015-07-08T18:57:11Z","updated_at":"2015-07-08T18:57:11Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:13Z","url":"https://www.pivotaltracker.com/story/show/98677186"},{"kind":"story","id":98677188,"project_id":<TRACKERPROJECT>,"name":"Full
-        production launch","story_type":"release","current_state":"unstarted","requested_by_id":379075,"owner_ids":[],"labels":[],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:13Z","url":"https://www.pivotaltracker.com/story/show/98677188"}],"start":"2016-04-11T00:00:00Z","finish":"2016-04-18T00:00:00Z"}]'
-    http_version: 
-  recorded_at: Wed, 29 Jul 2015 14:47:39 GMT
+  recorded_at: Wed, 29 Jul 2015 14:48:50 GMT
 recorded_with: VCR 2.9.3

--- a/spec/cassettes/Story_review_process/as_an_admin/lists_all_the_submitted_stories_in_the_system.yml
+++ b/spec/cassettes/Story_review_process/as_an_admin/lists_all_the_submitted_stories_in_the_system.yml
@@ -29,11 +29,11 @@ http_interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - d3a0a7d0dbff606a387c2a192371aa84
+      - c749b3fcdb61aef84c752d2742d48c3b
       X-Runtime:
-      - '0.051315'
+      - '0.042617'
       Date:
-      - Tue, 28 Jul 2015 17:14:24 GMT
+      - Wed, 29 Jul 2015 14:47:33 GMT
       X-Rack-Cache:
       - miss
       X-Powered-By:
@@ -56,7 +56,7 @@ http_interactions:
         is a demo project, created by Tracker, with example stories for a simple shopping
         web site.","enable_incoming_emails":true,"initial_velocity":10,"public":false,"atom_enabled":false,"project_type":"demo","start_time":"2015-06-22T00:00:00Z","created_at":"2015-07-08T18:57:11Z","updated_at":"2015-07-08T19:01:19Z","account_id":774272,"current_iteration_number":6,"enable_following":true}'
     http_version: 
-  recorded_at: Tue, 28 Jul 2015 17:14:27 GMT
+  recorded_at: Wed, 29 Jul 2015 14:47:32 GMT
 - request:
     method: get
     uri: https://www.pivotaltracker.com/services/v5/projects/<TRACKERPROJECT>/iterations?scope=current_backlog
@@ -94,11 +94,11 @@ http_interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - cfe7840854a54a324407200fb55ba8a5
+      - 9d8c208db05822aea362755deecebb28
       X-Runtime:
-      - '0.034824'
+      - '0.043911'
       Date:
-      - Tue, 28 Jul 2015 17:14:24 GMT
+      - Wed, 29 Jul 2015 14:47:33 GMT
       X-Rack-Cache:
       - miss
       X-Powered-By:
@@ -146,7 +146,7 @@ http_interactions:
         should be able to enter credit card information and shipping address","story_type":"feature","current_state":"unstarted","estimate":1,"requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166944,"project_id":<TRACKERPROJECT>,"name":"checkout","created_at":"2015-07-08T18:57:12Z","updated_at":"2015-07-08T18:57:12Z"},{"kind":"label","id":12166936,"project_id":<TRACKERPROJECT>,"name":"shopping","created_at":"2015-07-08T18:57:11Z","updated_at":"2015-07-08T18:57:11Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677120"},{"kind":"story","id":98677122,"project_id":<TRACKERPROJECT>,"name":"Integrate
         with payment gateway","story_type":"chore","current_state":"unstarted","requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166944,"project_id":<TRACKERPROJECT>,"name":"checkout","created_at":"2015-07-08T18:57:12Z","updated_at":"2015-07-08T18:57:12Z"},{"kind":"label","id":12166936,"project_id":<TRACKERPROJECT>,"name":"shopping","created_at":"2015-07-08T18:57:11Z","updated_at":"2015-07-08T18:57:11Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677122"}],"start":"2015-09-14T00:00:00Z","finish":"2015-09-21T00:00:00Z"},{"kind":"iteration","number":14,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[],"start":"2015-09-21T00:00:00Z","finish":"2015-09-28T00:00:00Z"},{"kind":"iteration","number":15,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[],"start":"2015-09-28T00:00:00Z","finish":"2015-10-05T00:00:00Z"}]'
     http_version: 
-  recorded_at: Tue, 28 Jul 2015 17:14:28 GMT
+  recorded_at: Wed, 29 Jul 2015 14:47:32 GMT
 - request:
     method: get
     uri: https://www.pivotaltracker.com/services/v5/projects/<TRACKERPROJECT>/iterations?limit=10&offset=10&scope=current_backlog
@@ -184,11 +184,11 @@ http_interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 0c1568bf3d9f62fc050d979f9bd56a80
+      - b81c73b843b7f67e13eceaf345623899
       X-Runtime:
-      - '0.040375'
+      - '0.041593'
       Date:
-      - Tue, 28 Jul 2015 17:14:24 GMT
+      - Wed, 29 Jul 2015 14:47:33 GMT
       X-Rack-Cache:
       - miss
       X-Powered-By:
@@ -225,7 +225,7 @@ http_interactions:
         up Engine Yard production environment","story_type":"chore","current_state":"unstarted","requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166932,"project_id":<TRACKERPROJECT>,"name":"deployment","created_at":"2015-07-08T18:57:11Z","updated_at":"2015-07-08T18:57:11Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677138"},{"kind":"story","id":98677140,"project_id":<TRACKERPROJECT>,"name":"Beta
         launch","story_type":"release","current_state":"unstarted","deadline":"2015-07-27T00:00:00Z","requested_by_id":379075,"owner_ids":[],"labels":[],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677140"}],"start":"2015-12-07T00:00:00Z","finish":"2015-12-14T00:00:00Z"}]'
     http_version: 
-  recorded_at: Tue, 28 Jul 2015 17:14:28 GMT
+  recorded_at: Wed, 29 Jul 2015 14:47:33 GMT
 - request:
     method: get
     uri: https://www.pivotaltracker.com/services/v5/projects/<TRACKERPROJECT>/iterations?limit=10&offset=20&scope=current_backlog
@@ -263,11 +263,11 @@ http_interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 89ab984d2a4c8cc4bf9de28f7a7212c6
+      - 364db11d0dc77112679cd074bc3e52af
       X-Runtime:
-      - '0.048913'
+      - '0.039044'
       Date:
-      - Tue, 28 Jul 2015 17:14:25 GMT
+      - Wed, 29 Jul 2015 14:47:33 GMT
       X-Rack-Cache:
       - miss
       X-Powered-By:
@@ -307,7 +307,7 @@ http_interactions:
         accounts","created_at":"2015-07-08T18:57:12Z","updated_at":"2015-07-08T18:57:12Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677156"},{"kind":"story","id":98677158,"project_id":<TRACKERPROJECT>,"name":"Provide
         feedback to designer about look/feel of site","story_type":"chore","current_state":"unstarted","requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166954,"project_id":<TRACKERPROJECT>,"name":"design","created_at":"2015-07-08T18:57:12Z","updated_at":"2015-07-08T18:57:12Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677158"}],"start":"2016-02-15T00:00:00Z","finish":"2016-02-22T00:00:00Z"}]'
     http_version: 
-  recorded_at: Tue, 28 Jul 2015 17:14:28 GMT
+  recorded_at: Wed, 29 Jul 2015 14:47:33 GMT
 - request:
     method: get
     uri: https://www.pivotaltracker.com/services/v5/projects/<TRACKERPROJECT>/iterations?limit=10&offset=30&scope=current_backlog
@@ -345,11 +345,11 @@ http_interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - f8a784b0d1b7b55204d16c9b630ae6dd
+      - d4785b35092d07f63de398f3aabe3a61
       X-Runtime:
-      - '0.046295'
+      - '0.038716'
       Date:
-      - Tue, 28 Jul 2015 17:14:25 GMT
+      - Wed, 29 Jul 2015 14:47:34 GMT
       X-Rack-Cache:
       - miss
       X-Powered-By:
@@ -393,5 +393,5 @@ http_interactions:
         higher number of production slices, for scaling","story_type":"chore","current_state":"unstarted","requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166932,"project_id":<TRACKERPROJECT>,"name":"deployment","created_at":"2015-07-08T18:57:11Z","updated_at":"2015-07-08T18:57:11Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:13Z","url":"https://www.pivotaltracker.com/story/show/98677186"},{"kind":"story","id":98677188,"project_id":<TRACKERPROJECT>,"name":"Full
         production launch","story_type":"release","current_state":"unstarted","requested_by_id":379075,"owner_ids":[],"labels":[],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:13Z","url":"https://www.pivotaltracker.com/story/show/98677188"}],"start":"2016-04-11T00:00:00Z","finish":"2016-04-18T00:00:00Z"}]'
     http_version: 
-  recorded_at: Tue, 28 Jul 2015 17:14:28 GMT
+  recorded_at: Wed, 29 Jul 2015 14:47:33 GMT
 recorded_with: VCR 2.9.3

--- a/spec/cassettes/Story_review_process/as_an_admin/lists_all_the_submitted_stories_in_the_system.yml
+++ b/spec/cassettes/Story_review_process/as_an_admin/lists_all_the_submitted_stories_in_the_system.yml
@@ -1,0 +1,397 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://www.pivotaltracker.com/services/v5/projects/<TRACKERPROJECT>
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Ruby/2.2.2 (x86_64-darwin14; ruby) TrackerApi/0.2.10 Faraday/0.9.1
+      X-Trackertoken:
+      - "<TRACKERAPITOKEN>"
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Status:
+      - 200 OK
+      X-Tracker-Project-Version:
+      - '60'
+      X-Ua-Compatible:
+      - IE=Edge,chrome=1
+      Etag:
+      - '"54ff79786816fdb6c6aecb294e18cd28"'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - d3a0a7d0dbff606a387c2a192371aa84
+      X-Runtime:
+      - '0.051315'
+      Date:
+      - Tue, 28 Jul 2015 17:14:24 GMT
+      X-Rack-Cache:
+      - miss
+      X-Powered-By:
+      - Phusion Passenger 4.0.41
+      Server:
+      - nginx/1.6.0 + Phusion Passenger 4.0.41
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Credentials:
+      - 'false'
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, DELETE, OPTIONS
+      Access-Control-Allow-Headers:
+      - X-TrackerToken,DNT,X-Mx-ReqToken,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,X-Tracker-Warn-Unless-Project-Version-Is
+      X-Tracker-Client-Pinger-Interval:
+      - '12'
+    body:
+      encoding: UTF-8
+      string: '{"id":<TRACKERPROJECT>,"kind":"project","name":"My Sample Project","version":60,"iteration_length":1,"week_start_day":"Monday","point_scale":"0,1,2,3","point_scale_is_custom":false,"bugs_and_chores_are_estimatable":false,"automatic_planning":true,"enable_tasks":true,"time_zone":{"kind":"time_zone","olson_name":"Etc/UTC","offset":"+00:00"},"velocity_averaged_over":3,"number_of_done_iterations_to_show":12,"has_google_domain":false,"profile_content":"This
+        is a demo project, created by Tracker, with example stories for a simple shopping
+        web site.","enable_incoming_emails":true,"initial_velocity":10,"public":false,"atom_enabled":false,"project_type":"demo","start_time":"2015-06-22T00:00:00Z","created_at":"2015-07-08T18:57:11Z","updated_at":"2015-07-08T19:01:19Z","account_id":774272,"current_iteration_number":6,"enable_following":true}'
+    http_version: 
+  recorded_at: Tue, 28 Jul 2015 17:14:27 GMT
+- request:
+    method: get
+    uri: https://www.pivotaltracker.com/services/v5/projects/<TRACKERPROJECT>/iterations?scope=current_backlog
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Ruby/2.2.2 (x86_64-darwin14; ruby) TrackerApi/0.2.10 Faraday/0.9.1
+      X-Trackertoken:
+      - "<TRACKERAPITOKEN>"
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Status:
+      - 200 OK
+      X-Tracker-Project-Version:
+      - '60'
+      X-Tracker-Pagination-Total:
+      - '38'
+      X-Tracker-Pagination-Offset:
+      - '0'
+      X-Tracker-Pagination-Limit:
+      - '10'
+      X-Tracker-Pagination-Returned:
+      - '10'
+      X-Ua-Compatible:
+      - IE=Edge,chrome=1
+      Etag:
+      - '"a45abde516f1b05b1d3db453cf2f1c66"'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - cfe7840854a54a324407200fb55ba8a5
+      X-Runtime:
+      - '0.034824'
+      Date:
+      - Tue, 28 Jul 2015 17:14:24 GMT
+      X-Rack-Cache:
+      - miss
+      X-Powered-By:
+      - Phusion Passenger 4.0.41
+      Server:
+      - nginx/1.6.0 + Phusion Passenger 4.0.41
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Credentials:
+      - 'false'
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, DELETE, OPTIONS
+      Access-Control-Allow-Headers:
+      - X-TrackerToken,DNT,X-Mx-ReqToken,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,X-Tracker-Warn-Unless-Project-Version-Is
+      X-Tracker-Client-Pinger-Interval:
+      - '12'
+    body:
+      encoding: UTF-8
+      string: '[{"kind":"iteration","number":6,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[{"kind":"story","id":98677104,"project_id":<TRACKERPROJECT>,"name":"Shopper
+        should be able to view contents of shopping cart","description":"Cart icon
+        in top right corner, with a number indicating how many items in cart","story_type":"feature","current_state":"delivered","estimate":2,"requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166940,"project_id":<TRACKERPROJECT>,"name":"cart","created_at":"2015-07-08T18:57:11Z","updated_at":"2015-07-08T18:57:11Z"},{"kind":"label","id":12166936,"project_id":<TRACKERPROJECT>,"name":"shopping","created_at":"2015-07-08T18:57:11Z","updated_at":"2015-07-08T18:57:11Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:11Z","url":"https://www.pivotaltracker.com/story/show/98677104"},{"kind":"story","id":98677106,"project_id":<TRACKERPROJECT>,"name":"Shopper
+        should be able to remove product from shopping cart","story_type":"feature","current_state":"delivered","estimate":1,"requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166940,"project_id":<TRACKERPROJECT>,"name":"cart","created_at":"2015-07-08T18:57:11Z","updated_at":"2015-07-08T18:57:11Z"},{"kind":"label","id":12166936,"project_id":<TRACKERPROJECT>,"name":"shopping","created_at":"2015-07-08T18:57:11Z","updated_at":"2015-07-08T18:57:11Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:11Z","url":"https://www.pivotaltracker.com/story/show/98677106"},{"kind":"story","id":98677108,"project_id":<TRACKERPROJECT>,"name":"Cart
+        manipulation should be AJAXy","story_type":"feature","current_state":"finished","estimate":1,"requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166940,"project_id":<TRACKERPROJECT>,"name":"cart","created_at":"2015-07-08T18:57:11Z","updated_at":"2015-07-08T18:57:11Z"},{"kind":"label","id":12166936,"project_id":<TRACKERPROJECT>,"name":"shopping","created_at":"2015-07-08T18:57:11Z","updated_at":"2015-07-08T18:57:11Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677108"},{"kind":"story","id":98677110,"project_id":<TRACKERPROJECT>,"name":"Some
+        product photos not scaled properly when browsing products","story_type":"bug","current_state":"started","requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166936,"project_id":<TRACKERPROJECT>,"name":"shopping","created_at":"2015-07-08T18:57:11Z","updated_at":"2015-07-08T18:57:11Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677110"},{"kind":"story","id":98677112,"project_id":<TRACKERPROJECT>,"name":"Shopper
+        should be able to recommend a product to a friend","description":"Prompt for
+        email address and personalized message, send email with product details and
+        message","story_type":"feature","current_state":"started","estimate":1,"requested_by_id":379075,"owned_by_id":379075,"owner_ids":[379075],"labels":[{"kind":"label","id":12166936,"project_id":<TRACKERPROJECT>,"name":"shopping","created_at":"2015-07-08T18:57:11Z","updated_at":"2015-07-08T18:57:11Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-21T17:01:29Z","url":"https://www.pivotaltracker.com/story/show/98677112"}],"start":"2015-07-27T00:00:00Z","finish":"2015-08-03T00:00:00Z"},{"kind":"iteration","number":7,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[{"kind":"story","id":98988674,"project_id":<TRACKERPROJECT>,"name":"As
+        a customer, I want slack integration","description":"\nAs an customer, I want
+        slack integration, so that I can stop importing invoices manually.\n\n## Acceptance
+        Criteria\n\n* \n* \n","story_type":"feature","current_state":"unstarted","requested_by_id":379075,"owner_ids":[],"labels":[],"created_at":"2015-07-13T21:28:52Z","updated_at":"2015-07-22T23:10:14Z","url":"https://www.pivotaltracker.com/story/show/98988674"},{"kind":"story","id":99533038,"project_id":<TRACKERPROJECT>,"name":"Adding
+        a new story to the list","description":"This is a new story","story_type":"feature","current_state":"unstarted","requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12276718,"project_id":<TRACKERPROJECT>,"name":"with_label","created_at":"2015-07-21T16:59:37Z","updated_at":"2015-07-21T16:59:37Z"}],"created_at":"2015-07-21T16:59:37Z","updated_at":"2015-07-22T23:06:53Z","url":"https://www.pivotaltracker.com/story/show/99533038"},{"kind":"story","id":99432476,"project_id":<TRACKERPROJECT>,"name":"As
+        a RMS user, I want everything","description":"\nAs an RMS user, I want everything,
+        so that make money.\n\n## Acceptance Criteria\n\n* \n* \n","story_type":"feature","current_state":"unstarted","requested_by_id":379075,"owner_ids":[],"labels":[],"created_at":"2015-07-20T16:23:00Z","updated_at":"2015-07-20T20:08:54Z","url":"https://www.pivotaltracker.com/story/show/99432476"}],"start":"2015-08-03T00:00:00Z","finish":"2015-08-10T00:00:00Z"},{"kind":"iteration","number":8,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[],"start":"2015-08-10T00:00:00Z","finish":"2015-08-17T00:00:00Z"},{"kind":"iteration","number":9,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[{"kind":"story","id":99380320,"project_id":<TRACKERPROJECT>,"name":"As
+        a another customer, I want stuff","description":"\nAs an another customer,
+        I want stuff, so that its very important.\n\n## Acceptance Criteria\n\n* \n*
+        \n","story_type":"feature","current_state":"unstarted","estimate":3,"requested_by_id":379075,"owner_ids":[],"labels":[],"created_at":"2015-07-19T23:38:54Z","updated_at":"2015-07-21T17:02:02Z","url":"https://www.pivotaltracker.com/story/show/99380320"},{"kind":"story","id":98677114,"project_id":<TRACKERPROJECT>,"name":"configure
+        solr for full text searching","story_type":"chore","current_state":"unstarted","requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166942,"project_id":<TRACKERPROJECT>,"name":"search","created_at":"2015-07-08T18:57:12Z","updated_at":"2015-07-08T18:57:12Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677114"},{"kind":"story","id":98688698,"project_id":<TRACKERPROJECT>,"name":"trying
+        to insert after configure solr","story_type":"feature","current_state":"unstarted","requested_by_id":379075,"owner_ids":[],"labels":[],"created_at":"2015-07-08T21:01:30Z","updated_at":"2015-07-08T21:01:30Z","url":"https://www.pivotaltracker.com/story/show/98688698"},{"kind":"story","id":99852954,"project_id":<TRACKERPROJECT>,"name":"As
+        a customer, I want slack integration","description":"\nAs an customer, I want
+        slack integration, so that I can stop importing invoices manually.\n\n## Acceptance
+        Criteria\n\n* \n* \n","story_type":"feature","current_state":"unstarted","requested_by_id":379075,"owner_ids":[],"labels":[],"created_at":"2015-07-26T02:58:46Z","updated_at":"2015-07-26T02:58:46Z","url":"https://www.pivotaltracker.com/story/show/99852954"}],"start":"2015-08-17T00:00:00Z","finish":"2015-08-24T00:00:00Z"},{"kind":"iteration","number":10,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[],"start":"2015-08-24T00:00:00Z","finish":"2015-08-31T00:00:00Z"},{"kind":"iteration","number":11,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[],"start":"2015-08-31T00:00:00Z","finish":"2015-09-07T00:00:00Z"},{"kind":"iteration","number":12,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[{"kind":"story","id":98677116,"project_id":<TRACKERPROJECT>,"name":"Shopper
+        should be able to search for product","description":"One search field, search
+        should look through product name, description, and SKU","story_type":"feature","current_state":"unstarted","estimate":3,"requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166942,"project_id":<TRACKERPROJECT>,"name":"search","created_at":"2015-07-08T18:57:12Z","updated_at":"2015-07-08T18:57:12Z"},{"kind":"label","id":12166936,"project_id":<TRACKERPROJECT>,"name":"shopping","created_at":"2015-07-08T18:57:11Z","updated_at":"2015-07-08T18:57:11Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677116"},{"kind":"story","id":98677118,"project_id":<TRACKERPROJECT>,"name":"Initial
+        demo to investors","story_type":"release","current_state":"unstarted","requested_by_id":379075,"owner_ids":[],"labels":[],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677118"}],"start":"2015-09-07T00:00:00Z","finish":"2015-09-14T00:00:00Z"},{"kind":"iteration","number":13,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[{"kind":"story","id":98677120,"project_id":<TRACKERPROJECT>,"name":"Shopper
+        should be able to enter credit card information and shipping address","story_type":"feature","current_state":"unstarted","estimate":1,"requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166944,"project_id":<TRACKERPROJECT>,"name":"checkout","created_at":"2015-07-08T18:57:12Z","updated_at":"2015-07-08T18:57:12Z"},{"kind":"label","id":12166936,"project_id":<TRACKERPROJECT>,"name":"shopping","created_at":"2015-07-08T18:57:11Z","updated_at":"2015-07-08T18:57:11Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677120"},{"kind":"story","id":98677122,"project_id":<TRACKERPROJECT>,"name":"Integrate
+        with payment gateway","story_type":"chore","current_state":"unstarted","requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166944,"project_id":<TRACKERPROJECT>,"name":"checkout","created_at":"2015-07-08T18:57:12Z","updated_at":"2015-07-08T18:57:12Z"},{"kind":"label","id":12166936,"project_id":<TRACKERPROJECT>,"name":"shopping","created_at":"2015-07-08T18:57:11Z","updated_at":"2015-07-08T18:57:11Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677122"}],"start":"2015-09-14T00:00:00Z","finish":"2015-09-21T00:00:00Z"},{"kind":"iteration","number":14,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[],"start":"2015-09-21T00:00:00Z","finish":"2015-09-28T00:00:00Z"},{"kind":"iteration","number":15,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[],"start":"2015-09-28T00:00:00Z","finish":"2015-10-05T00:00:00Z"}]'
+    http_version: 
+  recorded_at: Tue, 28 Jul 2015 17:14:28 GMT
+- request:
+    method: get
+    uri: https://www.pivotaltracker.com/services/v5/projects/<TRACKERPROJECT>/iterations?limit=10&offset=10&scope=current_backlog
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Ruby/2.2.2 (x86_64-darwin14; ruby) TrackerApi/0.2.10 Faraday/0.9.1
+      X-Trackertoken:
+      - "<TRACKERAPITOKEN>"
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Status:
+      - 200 OK
+      X-Tracker-Project-Version:
+      - '60'
+      X-Tracker-Pagination-Total:
+      - '38'
+      X-Tracker-Pagination-Offset:
+      - '10'
+      X-Tracker-Pagination-Limit:
+      - '10'
+      X-Tracker-Pagination-Returned:
+      - '10'
+      X-Ua-Compatible:
+      - IE=Edge,chrome=1
+      Etag:
+      - '"605d5ce640c91e3bf2a19a2d44f31c02"'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 0c1568bf3d9f62fc050d979f9bd56a80
+      X-Runtime:
+      - '0.040375'
+      Date:
+      - Tue, 28 Jul 2015 17:14:24 GMT
+      X-Rack-Cache:
+      - miss
+      X-Powered-By:
+      - Phusion Passenger 4.0.41
+      Server:
+      - nginx/1.6.0 + Phusion Passenger 4.0.41
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Credentials:
+      - 'false'
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, DELETE, OPTIONS
+      Access-Control-Allow-Headers:
+      - X-TrackerToken,DNT,X-Mx-ReqToken,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,X-Tracker-Warn-Unless-Project-Version-Is
+      X-Tracker-Client-Pinger-Interval:
+      - '12'
+    body:
+      encoding: UTF-8
+      string: '[{"kind":"iteration","number":16,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[{"kind":"story","id":98677124,"project_id":<TRACKERPROJECT>,"name":"When
+        shopper submits order, authorize total product amount from payment gateway","story_type":"feature","current_state":"unstarted","estimate":3,"requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166944,"project_id":<TRACKERPROJECT>,"name":"checkout","created_at":"2015-07-08T18:57:12Z","updated_at":"2015-07-08T18:57:12Z"},{"kind":"label","id":12166946,"project_id":<TRACKERPROJECT>,"name":"needs
+        discussion","created_at":"2015-07-08T18:57:12Z","updated_at":"2015-07-08T18:57:12Z"},{"kind":"label","id":12166936,"project_id":<TRACKERPROJECT>,"name":"shopping","created_at":"2015-07-08T18:57:11Z","updated_at":"2015-07-08T18:57:11Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677124"}],"start":"2015-10-05T00:00:00Z","finish":"2015-10-12T00:00:00Z"},{"kind":"iteration","number":17,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[{"kind":"story","id":98677126,"project_id":<TRACKERPROJECT>,"name":"If
+        system fails to authorize payment amount, display error message to shopper","story_type":"feature","current_state":"unstarted","estimate":1,"requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166944,"project_id":<TRACKERPROJECT>,"name":"checkout","created_at":"2015-07-08T18:57:12Z","updated_at":"2015-07-08T18:57:12Z"},{"kind":"label","id":12166936,"project_id":<TRACKERPROJECT>,"name":"shopping","created_at":"2015-07-08T18:57:11Z","updated_at":"2015-07-08T18:57:11Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677126"}],"start":"2015-10-12T00:00:00Z","finish":"2015-10-19T00:00:00Z"},{"kind":"iteration","number":18,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[{"kind":"story","id":98677128,"project_id":<TRACKERPROJECT>,"name":"If
+        authorization is successful, show order number and confirmation message to
+        shopper","story_type":"feature","current_state":"unstarted","estimate":1,"requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166944,"project_id":<TRACKERPROJECT>,"name":"checkout","created_at":"2015-07-08T18:57:12Z","updated_at":"2015-07-08T18:57:12Z"},{"kind":"label","id":12166936,"project_id":<TRACKERPROJECT>,"name":"shopping","created_at":"2015-07-08T18:57:11Z","updated_at":"2015-07-08T18:57:11Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677128"},{"kind":"story","id":98688754,"project_id":<TRACKERPROJECT>,"name":"Foo
+        Bar 2","story_type":"feature","current_state":"unstarted","requested_by_id":379075,"owner_ids":[],"labels":[],"created_at":"2015-07-08T21:02:19Z","updated_at":"2015-07-08T21:02:19Z","url":"https://www.pivotaltracker.com/story/show/98688754"}],"start":"2015-10-19T00:00:00Z","finish":"2015-10-26T00:00:00Z"},{"kind":"iteration","number":19,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[],"start":"2015-10-26T00:00:00Z","finish":"2015-11-02T00:00:00Z"},{"kind":"iteration","number":20,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[{"kind":"story","id":99260190,"project_id":<TRACKERPROJECT>,"name":"As
+        a fdoo, I want bar","description":"\nAs an fdoo, I want bar, so that baz.\n\n##
+        Acceptance Criteria\n\n* \n* \n","story_type":"feature","current_state":"unstarted","estimate":2,"requested_by_id":379075,"owner_ids":[],"labels":[],"created_at":"2015-07-16T20:49:18Z","updated_at":"2015-07-16T21:00:42Z","url":"https://www.pivotaltracker.com/story/show/99260190"}],"start":"2015-11-02T00:00:00Z","finish":"2015-11-09T00:00:00Z"},{"kind":"iteration","number":21,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[{"kind":"story","id":98677130,"project_id":<TRACKERPROJECT>,"name":"Send
+        notification email of order placement to admin","story_type":"feature","current_state":"unstarted","estimate":1,"requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166934,"project_id":<TRACKERPROJECT>,"name":"admin","created_at":"2015-07-08T18:57:11Z","updated_at":"2015-07-08T18:57:11Z"},{"kind":"label","id":12166944,"project_id":<TRACKERPROJECT>,"name":"checkout","created_at":"2015-07-08T18:57:12Z","updated_at":"2015-07-08T18:57:12Z"},{"kind":"label","id":12166936,"project_id":<TRACKERPROJECT>,"name":"shopping","created_at":"2015-07-08T18:57:11Z","updated_at":"2015-07-08T18:57:11Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677130"}],"start":"2015-11-09T00:00:00Z","finish":"2015-11-16T00:00:00Z"},{"kind":"iteration","number":22,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[],"start":"2015-11-16T00:00:00Z","finish":"2015-11-23T00:00:00Z"},{"kind":"iteration","number":23,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[{"kind":"story","id":98677132,"project_id":<TRACKERPROJECT>,"name":"Shopper
+        should be able to check status of order by entering name and order number","story_type":"feature","current_state":"unstarted","estimate":2,"requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166948,"project_id":<TRACKERPROJECT>,"name":"orders","created_at":"2015-07-08T18:57:12Z","updated_at":"2015-07-08T18:57:12Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677132"}],"start":"2015-11-23T00:00:00Z","finish":"2015-11-30T00:00:00Z"},{"kind":"iteration","number":24,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[{"kind":"story","id":98677134,"project_id":<TRACKERPROJECT>,"name":"Shopper
+        should be able to ask question about order","description":"When checking status
+        of order, shopper should have the option to ask a question. This should send
+        email to admin.","story_type":"feature","current_state":"unstarted","estimate":1,"requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166948,"project_id":<TRACKERPROJECT>,"name":"orders","created_at":"2015-07-08T18:57:12Z","updated_at":"2015-07-08T18:57:12Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677134"}],"start":"2015-11-30T00:00:00Z","finish":"2015-12-07T00:00:00Z"},{"kind":"iteration","number":25,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[{"kind":"story","id":98677136,"project_id":<TRACKERPROJECT>,"name":"Admin
+        can review all order questions and send responses to shoppers","story_type":"feature","current_state":"unstarted","estimate":1,"requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166934,"project_id":<TRACKERPROJECT>,"name":"admin","created_at":"2015-07-08T18:57:11Z","updated_at":"2015-07-08T18:57:11Z"},{"kind":"label","id":12166948,"project_id":<TRACKERPROJECT>,"name":"orders","created_at":"2015-07-08T18:57:12Z","updated_at":"2015-07-08T18:57:12Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677136"},{"kind":"story","id":98677138,"project_id":<TRACKERPROJECT>,"name":"Set
+        up Engine Yard production environment","story_type":"chore","current_state":"unstarted","requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166932,"project_id":<TRACKERPROJECT>,"name":"deployment","created_at":"2015-07-08T18:57:11Z","updated_at":"2015-07-08T18:57:11Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677138"},{"kind":"story","id":98677140,"project_id":<TRACKERPROJECT>,"name":"Beta
+        launch","story_type":"release","current_state":"unstarted","deadline":"2015-07-27T00:00:00Z","requested_by_id":379075,"owner_ids":[],"labels":[],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677140"}],"start":"2015-12-07T00:00:00Z","finish":"2015-12-14T00:00:00Z"}]'
+    http_version: 
+  recorded_at: Tue, 28 Jul 2015 17:14:28 GMT
+- request:
+    method: get
+    uri: https://www.pivotaltracker.com/services/v5/projects/<TRACKERPROJECT>/iterations?limit=10&offset=20&scope=current_backlog
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Ruby/2.2.2 (x86_64-darwin14; ruby) TrackerApi/0.2.10 Faraday/0.9.1
+      X-Trackertoken:
+      - "<TRACKERAPITOKEN>"
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Status:
+      - 200 OK
+      X-Tracker-Project-Version:
+      - '60'
+      X-Tracker-Pagination-Total:
+      - '38'
+      X-Tracker-Pagination-Offset:
+      - '20'
+      X-Tracker-Pagination-Limit:
+      - '10'
+      X-Tracker-Pagination-Returned:
+      - '10'
+      X-Ua-Compatible:
+      - IE=Edge,chrome=1
+      Etag:
+      - '"6d672d053b6acbac48e7708ae2286b55"'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 89ab984d2a4c8cc4bf9de28f7a7212c6
+      X-Runtime:
+      - '0.048913'
+      Date:
+      - Tue, 28 Jul 2015 17:14:25 GMT
+      X-Rack-Cache:
+      - miss
+      X-Powered-By:
+      - Phusion Passenger 4.0.41
+      Server:
+      - nginx/1.6.0 + Phusion Passenger 4.0.41
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Credentials:
+      - 'false'
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, DELETE, OPTIONS
+      Access-Control-Allow-Headers:
+      - X-TrackerToken,DNT,X-Mx-ReqToken,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,X-Tracker-Warn-Unless-Project-Version-Is
+      X-Tracker-Client-Pinger-Interval:
+      - '12'
+    body:
+      encoding: UTF-8
+      string: '[{"kind":"iteration","number":26,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[],"start":"2015-12-14T00:00:00Z","finish":"2015-12-21T00:00:00Z"},{"kind":"iteration","number":27,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[{"kind":"story","id":98677142,"project_id":<TRACKERPROJECT>,"name":"Shopper
+        should be able to sign up for an account with email address","story_type":"feature","current_state":"unstarted","estimate":2,"requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166950,"project_id":<TRACKERPROJECT>,"name":"signup
+        / signin","created_at":"2015-07-08T18:57:12Z","updated_at":"2015-07-08T18:57:12Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677142"}],"start":"2015-12-21T00:00:00Z","finish":"2015-12-28T00:00:00Z"},{"kind":"iteration","number":28,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[{"kind":"story","id":98677144,"project_id":<TRACKERPROJECT>,"name":"Shopper
+        should be able to reset forgotten password","story_type":"feature","current_state":"unstarted","estimate":1,"requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166950,"project_id":<TRACKERPROJECT>,"name":"signup
+        / signin","created_at":"2015-07-08T18:57:12Z","updated_at":"2015-07-08T18:57:12Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677144"}],"start":"2015-12-28T00:00:00Z","finish":"2016-01-04T00:00:00Z"},{"kind":"iteration","number":29,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[{"kind":"story","id":98677146,"project_id":<TRACKERPROJECT>,"name":"Shopper
+        should be able to log out","story_type":"feature","current_state":"unstarted","estimate":1,"requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166950,"project_id":<TRACKERPROJECT>,"name":"signup
+        / signin","created_at":"2015-07-08T18:57:12Z","updated_at":"2015-07-08T18:57:12Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677146"}],"start":"2016-01-04T00:00:00Z","finish":"2016-01-11T00:00:00Z"},{"kind":"iteration","number":30,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[{"kind":"story","id":98677148,"project_id":<TRACKERPROJECT>,"name":"When
+        checking out, shopper should have the option to sign in to their account","story_type":"feature","current_state":"unstarted","estimate":1,"requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166950,"project_id":<TRACKERPROJECT>,"name":"signup
+        / signin","created_at":"2015-07-08T18:57:12Z","updated_at":"2015-07-08T18:57:12Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677148"}],"start":"2016-01-11T00:00:00Z","finish":"2016-01-18T00:00:00Z"},{"kind":"iteration","number":31,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[{"kind":"story","id":98677150,"project_id":<TRACKERPROJECT>,"name":"Signed
+        in shopper should be able to review order history","description":"Show orders
+        in last 60 days, with link to show older orders","story_type":"feature","current_state":"unstarted","estimate":1,"requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166952,"project_id":<TRACKERPROJECT>,"name":"shopper
+        accounts","created_at":"2015-07-08T18:57:12Z","updated_at":"2015-07-08T18:57:12Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677150"}],"start":"2016-01-18T00:00:00Z","finish":"2016-01-25T00:00:00Z"},{"kind":"iteration","number":32,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[],"start":"2016-01-25T00:00:00Z","finish":"2016-02-01T00:00:00Z"},{"kind":"iteration","number":33,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[{"kind":"story","id":98677152,"project_id":<TRACKERPROJECT>,"name":"Signed
+        in shopper should be able to save credit card and address information used
+        in checkout","description":"Credit card numbers should be stored encrypted","story_type":"feature","current_state":"unstarted","estimate":2,"requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166952,"project_id":<TRACKERPROJECT>,"name":"shopper
+        accounts","created_at":"2015-07-08T18:57:12Z","updated_at":"2015-07-08T18:57:12Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677152"}],"start":"2016-02-01T00:00:00Z","finish":"2016-02-08T00:00:00Z"},{"kind":"iteration","number":34,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[{"kind":"story","id":98677154,"project_id":<TRACKERPROJECT>,"name":"Signed
+        in shopper should be able to save product to favorites","story_type":"feature","current_state":"unstarted","estimate":1,"requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166952,"project_id":<TRACKERPROJECT>,"name":"shopper
+        accounts","created_at":"2015-07-08T18:57:12Z","updated_at":"2015-07-08T18:57:12Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677154"}],"start":"2016-02-08T00:00:00Z","finish":"2016-02-15T00:00:00Z"},{"kind":"iteration","number":35,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[{"kind":"story","id":98677156,"project_id":<TRACKERPROJECT>,"name":"Signed
+        in shopper should be able to review and remove product from favorites","story_type":"feature","current_state":"unstarted","estimate":1,"requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166952,"project_id":<TRACKERPROJECT>,"name":"shopper
+        accounts","created_at":"2015-07-08T18:57:12Z","updated_at":"2015-07-08T18:57:12Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677156"},{"kind":"story","id":98677158,"project_id":<TRACKERPROJECT>,"name":"Provide
+        feedback to designer about look/feel of site","story_type":"chore","current_state":"unstarted","requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166954,"project_id":<TRACKERPROJECT>,"name":"design","created_at":"2015-07-08T18:57:12Z","updated_at":"2015-07-08T18:57:12Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677158"}],"start":"2016-02-15T00:00:00Z","finish":"2016-02-22T00:00:00Z"}]'
+    http_version: 
+  recorded_at: Tue, 28 Jul 2015 17:14:28 GMT
+- request:
+    method: get
+    uri: https://www.pivotaltracker.com/services/v5/projects/<TRACKERPROJECT>/iterations?limit=10&offset=30&scope=current_backlog
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Ruby/2.2.2 (x86_64-darwin14; ruby) TrackerApi/0.2.10 Faraday/0.9.1
+      X-Trackertoken:
+      - "<TRACKERAPITOKEN>"
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Status:
+      - 200 OK
+      X-Tracker-Project-Version:
+      - '60'
+      X-Tracker-Pagination-Total:
+      - '38'
+      X-Tracker-Pagination-Offset:
+      - '30'
+      X-Tracker-Pagination-Limit:
+      - '10'
+      X-Tracker-Pagination-Returned:
+      - '8'
+      X-Ua-Compatible:
+      - IE=Edge,chrome=1
+      Etag:
+      - '"33834fa7c8aa742f6387c9d3c31fd6c5"'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - f8a784b0d1b7b55204d16c9b630ae6dd
+      X-Runtime:
+      - '0.046295'
+      Date:
+      - Tue, 28 Jul 2015 17:14:25 GMT
+      X-Rack-Cache:
+      - miss
+      X-Powered-By:
+      - Phusion Passenger 4.0.41
+      Server:
+      - nginx/1.6.0 + Phusion Passenger 4.0.41
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Credentials:
+      - 'false'
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, DELETE, OPTIONS
+      Access-Control-Allow-Headers:
+      - X-TrackerToken,DNT,X-Mx-ReqToken,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,X-Tracker-Warn-Unless-Project-Version-Is
+      X-Tracker-Client-Pinger-Interval:
+      - '12'
+    body:
+      encoding: UTF-8
+      string: '[{"kind":"iteration","number":36,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[],"start":"2016-02-22T00:00:00Z","finish":"2016-02-29T00:00:00Z"},{"kind":"iteration","number":37,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[],"start":"2016-02-29T00:00:00Z","finish":"2016-03-07T00:00:00Z"},{"kind":"iteration","number":38,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[{"kind":"story","id":98677160,"project_id":<TRACKERPROJECT>,"name":"Apply
+        styling to all shopper facing parts of the site, based on assets from designer","story_type":"feature","current_state":"unstarted","estimate":3,"requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166954,"project_id":<TRACKERPROJECT>,"name":"design","created_at":"2015-07-08T18:57:12Z","updated_at":"2015-07-08T18:57:12Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677160"}],"start":"2016-03-07T00:00:00Z","finish":"2016-03-14T00:00:00Z"},{"kind":"iteration","number":39,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[],"start":"2016-03-14T00:00:00Z","finish":"2016-03-21T00:00:00Z"},{"kind":"iteration","number":40,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[{"kind":"story","id":98677162,"project_id":<TRACKERPROJECT>,"name":"Signed
+        in shopper should be able to post product reviews","story_type":"feature","current_state":"unstarted","estimate":2,"requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166956,"project_id":<TRACKERPROJECT>,"name":"user
+        generated content","created_at":"2015-07-08T18:57:12Z","updated_at":"2015-07-08T18:57:12Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677162"}],"start":"2016-03-21T00:00:00Z","finish":"2016-03-28T00:00:00Z"},{"kind":"iteration","number":41,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[{"kind":"story","id":98677164,"project_id":<TRACKERPROJECT>,"name":"Signed
+        in shopper should be able to rate product, by choosing 1-5 stars","story_type":"feature","current_state":"unstarted","estimate":1,"requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166956,"project_id":<TRACKERPROJECT>,"name":"user
+        generated content","created_at":"2015-07-08T18:57:12Z","updated_at":"2015-07-08T18:57:12Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:12Z","url":"https://www.pivotaltracker.com/story/show/98677164"}],"start":"2016-03-28T00:00:00Z","finish":"2016-04-04T00:00:00Z"},{"kind":"iteration","number":42,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[{"kind":"story","id":98677166,"project_id":<TRACKERPROJECT>,"name":"When
+        shopper is browsing products, show average product rating and number of reviews
+        next to each product","story_type":"feature","current_state":"unstarted","estimate":1,"requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166956,"project_id":<TRACKERPROJECT>,"name":"user
+        generated content","created_at":"2015-07-08T18:57:12Z","updated_at":"2015-07-08T18:57:12Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:13Z","url":"https://www.pivotaltracker.com/story/show/98677166"}],"start":"2016-04-04T00:00:00Z","finish":"2016-04-11T00:00:00Z"},{"kind":"iteration","number":43,"project_id":<TRACKERPROJECT>,"team_strength":1,"stories":[{"kind":"story","id":98677168,"project_id":<TRACKERPROJECT>,"name":"Shopper
+        should be able to read reviews for a product","story_type":"feature","current_state":"unstarted","estimate":1,"requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166956,"project_id":<TRACKERPROJECT>,"name":"user
+        generated content","created_at":"2015-07-08T18:57:12Z","updated_at":"2015-07-08T18:57:12Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:13Z","url":"https://www.pivotaltracker.com/story/show/98677168"},{"kind":"story","id":98677170,"project_id":<TRACKERPROJECT>,"name":"Admin
+        should be able to mark a product as featured","story_type":"feature","current_state":"unstarted","requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166934,"project_id":<TRACKERPROJECT>,"name":"admin","created_at":"2015-07-08T18:57:11Z","updated_at":"2015-07-08T18:57:11Z"},{"kind":"label","id":12166958,"project_id":<TRACKERPROJECT>,"name":"featured
+        products","created_at":"2015-07-08T18:57:13Z","updated_at":"2015-07-08T18:57:13Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:13Z","url":"https://www.pivotaltracker.com/story/show/98677170"},{"kind":"story","id":98677172,"project_id":<TRACKERPROJECT>,"name":"Featured
+        products should appear on the site landing page","story_type":"feature","current_state":"unstarted","requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166958,"project_id":<TRACKERPROJECT>,"name":"featured
+        products","created_at":"2015-07-08T18:57:13Z","updated_at":"2015-07-08T18:57:13Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:13Z","url":"https://www.pivotaltracker.com/story/show/98677172"},{"kind":"story","id":98677174,"project_id":<TRACKERPROJECT>,"name":"Admin
+        should be able to create and edit blog articles","story_type":"feature","current_state":"unstarted","requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166934,"project_id":<TRACKERPROJECT>,"name":"admin","created_at":"2015-07-08T18:57:11Z","updated_at":"2015-07-08T18:57:11Z"},{"kind":"label","id":12166960,"project_id":<TRACKERPROJECT>,"name":"blog","created_at":"2015-07-08T18:57:13Z","updated_at":"2015-07-08T18:57:13Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:13Z","url":"https://www.pivotaltracker.com/story/show/98677174"},{"kind":"story","id":98677176,"project_id":<TRACKERPROJECT>,"name":"Admin
+        should be able to save blog articles in draft mode","story_type":"feature","current_state":"unstarted","requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166934,"project_id":<TRACKERPROJECT>,"name":"admin","created_at":"2015-07-08T18:57:11Z","updated_at":"2015-07-08T18:57:11Z"},{"kind":"label","id":12166960,"project_id":<TRACKERPROJECT>,"name":"blog","created_at":"2015-07-08T18:57:13Z","updated_at":"2015-07-08T18:57:13Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:13Z","url":"https://www.pivotaltracker.com/story/show/98677176"},{"kind":"story","id":98677178,"project_id":<TRACKERPROJECT>,"name":"Published
+        blog articles should appear on the site","story_type":"feature","current_state":"unstarted","requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166960,"project_id":<TRACKERPROJECT>,"name":"blog","created_at":"2015-07-08T18:57:13Z","updated_at":"2015-07-08T18:57:13Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:13Z","url":"https://www.pivotaltracker.com/story/show/98677178"},{"kind":"story","id":98677180,"project_id":<TRACKERPROJECT>,"name":"People
+        should be able to subscribe to blog via RSS and Atom","story_type":"feature","current_state":"unstarted","requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166960,"project_id":<TRACKERPROJECT>,"name":"blog","created_at":"2015-07-08T18:57:13Z","updated_at":"2015-07-08T18:57:13Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:13Z","url":"https://www.pivotaltracker.com/story/show/98677180"},{"kind":"story","id":98677182,"project_id":<TRACKERPROJECT>,"name":"Admin
+        should be able to view monthly sales report","story_type":"feature","current_state":"unstarted","requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166934,"project_id":<TRACKERPROJECT>,"name":"admin","created_at":"2015-07-08T18:57:11Z","updated_at":"2015-07-08T18:57:11Z"},{"kind":"label","id":12166962,"project_id":<TRACKERPROJECT>,"name":"reporting","created_at":"2015-07-08T18:57:13Z","updated_at":"2015-07-08T18:57:13Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:13Z","url":"https://www.pivotaltracker.com/story/show/98677182"},{"kind":"story","id":98677184,"project_id":<TRACKERPROJECT>,"name":"Admin
+        should be able to export orders as CSV file, based on date range and order
+        status","story_type":"feature","current_state":"unstarted","requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166934,"project_id":<TRACKERPROJECT>,"name":"admin","created_at":"2015-07-08T18:57:11Z","updated_at":"2015-07-08T18:57:11Z"},{"kind":"label","id":12166962,"project_id":<TRACKERPROJECT>,"name":"reporting","created_at":"2015-07-08T18:57:13Z","updated_at":"2015-07-08T18:57:13Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:13Z","url":"https://www.pivotaltracker.com/story/show/98677184"},{"kind":"story","id":98677186,"project_id":<TRACKERPROJECT>,"name":"Request
+        higher number of production slices, for scaling","story_type":"chore","current_state":"unstarted","requested_by_id":379075,"owner_ids":[],"labels":[{"kind":"label","id":12166932,"project_id":<TRACKERPROJECT>,"name":"deployment","created_at":"2015-07-08T18:57:11Z","updated_at":"2015-07-08T18:57:11Z"}],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:13Z","url":"https://www.pivotaltracker.com/story/show/98677186"},{"kind":"story","id":98677188,"project_id":<TRACKERPROJECT>,"name":"Full
+        production launch","story_type":"release","current_state":"unstarted","requested_by_id":379075,"owner_ids":[],"labels":[],"created_at":"2015-06-29T00:00:00Z","updated_at":"2015-07-08T18:57:13Z","url":"https://www.pivotaltracker.com/story/show/98677188"}],"start":"2016-04-11T00:00:00Z","finish":"2016-04-18T00:00:00Z"}]'
+    http_version: 
+  recorded_at: Tue, 28 Jul 2015 17:14:28 GMT
+recorded_with: VCR 2.9.3

--- a/spec/factories/stories.rb
+++ b/spec/factories/stories.rb
@@ -1,5 +1,23 @@
 FactoryGirl.define do
   factory :story do
+    name 'As a customer, I want foo bar'
+    description 'As an boss, I want another drink, so that I get drunk'
+
+    factory :full_story, traits: [:with_user]
+
+    trait :as_approved do
+      after(:create) do |obj|
+        obj.state = :approved
+        obj.external_ref = '123'
+        obj.save(validate: false)
+      end
+    end
+
+    trait :as_rejected do
+      after(:create) do |obj|
+        obj.reject!
+      end
+    end
 
     trait :with_user do
       user

--- a/spec/features/story_review_spec.rb
+++ b/spec/features/story_review_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+
+RSpec.describe 'Story review process', feature: :feature, omniauth: true, vcr: true do
+  before do
+    FactoryGirl.create_list(:full_story, 2)
+    FactoryGirl.create_list(:full_story, 1, :as_approved)
+    FactoryGirl.create_list(:full_story, 1, :as_rejected)
+  end
+
+  context 'as a non-admin' do
+    it 'restricts regular users from viewing the page' do
+      signin(as_new_user: false, role: 'regular_user')
+      visit '/stories'
+
+      expect(page).to have_text('You cannot perform this action.')
+      expect(current_path).to_not eql('/stories')
+    end
+
+    it 'restricts regular users from viewing the page' do
+      signin(as_new_user: false, role: 'viewer')
+      visit '/stories'
+
+      expect(page).to have_text('You cannot perform this action.')
+      expect(current_path).to_not eql('/stories')
+    end
+  end
+
+  context 'as an admin' do
+    before do
+      signin(as_new_user: false, role: 'admin')
+      visit '/stories'
+    end
+
+    it 'lists all the submitted stories in the system' do
+      expect(page).to have_css('.stories .story', count: 2)
+    end
+  end
+end

--- a/spec/features/story_review_spec.rb
+++ b/spec/features/story_review_spec.rb
@@ -34,5 +34,15 @@ RSpec.describe 'Story review process', feature: :feature, omniauth: true, vcr: t
     it 'lists all the submitted stories in the system' do
       expect(page).to have_css('.stories .story', count: 2)
     end
+
+    it 'has the ability to approve and reject' do
+      expect(page).to have_css('.stories .story', count: 2)
+      first('.story').click_on('Approve')
+      expect(page).to have_text('Story has been approved.')
+      expect(page).to have_css('.stories .story', count: 1)
+      first('.story').click_on('Reject')
+      expect(page).to have_text('Story has been rejected.')
+      expect(page).to_not have_css('.stories .story')
+    end
   end
 end

--- a/spec/policies/story_policy_spec.rb
+++ b/spec/policies/story_policy_spec.rb
@@ -7,6 +7,17 @@ describe StoryPolicy do
   let (:viewer) { FactoryGirl.build_stubbed :user }
   let (:admin) { FactoryGirl.build_stubbed :user, :admin }
 
+  permissions :index? do
+    it "denies access if not an admin" do
+      expect(subject).not_to permit(current_user)
+      expect(subject).not_to permit(viewer)
+    end
+
+    it "allows access for an admin" do
+      expect(subject).to permit(admin)
+    end
+  end
+
   permissions :create? do
     it "prevents create if not an admin" do
       expect(subject).not_to permit(viewer)

--- a/spec/policies/story_policy_spec.rb
+++ b/spec/policies/story_policy_spec.rb
@@ -30,4 +30,14 @@ describe StoryPolicy do
     end
   end
 
+  permissions :update? do
+    it "denies access if not an admin" do
+      expect(subject).not_to permit(current_user)
+      expect(subject).not_to permit(viewer)
+    end
+
+    it "allows access for an admin" do
+      expect(subject).to permit(admin)
+    end
+  end
 end

--- a/spec/policies/user_policy_spec.rb
+++ b/spec/policies/user_policy_spec.rb
@@ -3,14 +3,17 @@ require 'rails_helper'
 describe UserPolicy do
   subject { described_class }
 
-  let (:current_user) { FactoryGirl.build_stubbed :user }
-  let (:other_user) { FactoryGirl.build_stubbed :user }
-  let (:admin) { FactoryGirl.build_stubbed :user, :admin }
+  let(:current_user) { FactoryGirl.build_stubbed :user }
+  let(:other_user) { FactoryGirl.build_stubbed :user }
+  let(:regular_user) { FactoryGirl.build_stubbed :user, :regular_user }
+  let(:admin) { FactoryGirl.build_stubbed :user, :admin }
 
   permissions :index? do
     it "denies access if not an admin" do
+      expect(UserPolicy).not_to permit(regular_user)
       expect(UserPolicy).not_to permit(current_user)
     end
+
     it "allows access for an admin" do
       expect(UserPolicy).to permit(admin)
     end
@@ -20,9 +23,11 @@ describe UserPolicy do
     it "prevents other users from seeing your profile" do
       expect(subject).not_to permit(current_user, other_user)
     end
+
     it "allows you to see your own profile" do
       expect(subject).to permit(current_user, current_user)
     end
+
     it "allows an admin to see any profile" do
       expect(subject).to permit(admin)
     end
@@ -32,6 +37,7 @@ describe UserPolicy do
     it "prevents updates if not an admin" do
       expect(subject).not_to permit(current_user)
     end
+
     it "allows an admin to make updates" do
       expect(subject).to permit(admin)
     end
@@ -41,6 +47,12 @@ describe UserPolicy do
     it "prevents deleting yourself" do
       expect(subject).not_to permit(current_user, current_user)
     end
+
+    it "prevents non admins from deleting users" do
+      expect(subject).not_to permit(current_user)
+      expect(subject).not_to permit(regular_user)
+    end
+
     it "allows an admin to delete any user" do
       expect(subject).to permit(admin, other_user)
     end


### PR DESCRIPTION
Story submissions are now triaged before entering Pivotal Tracker. An admin must either approve or reject stories until PT even knows about them.

This comes with downsides. For example if a Story exists with a set `after_id` value and between submission and triage that story is moved or deleted, the approval will fail or enter the Story in an unexpected location.